### PR TITLE
Combine onMessage and onHalfClose callbacks into single call to avoid race condition

### DIFF
--- a/sdk-core-impl/src/main/java/dev/restate/sdk/core/impl/RestateServerCall.java
+++ b/sdk-core-impl/src/main/java/dev/restate/sdk/core/impl/RestateServerCall.java
@@ -30,7 +30,7 @@ class RestateServerCall extends ServerCall<MessageLite, MessageLite> {
   //
   // The listener reference is volatile in order to guarantee its visibility when the ownership of
   // this object is transferred through threads.
-  private volatile ServerCall.Listener<MessageLite> listener;
+  private volatile RestateServerCallListener<MessageLite> listener;
 
   // These variables don't need to be volatile as they're accessed and mutated only by
   // #setListener() and #request()
@@ -45,7 +45,7 @@ class RestateServerCall extends ServerCall<MessageLite, MessageLite> {
 
   // --- Invoked in the State machine thread
 
-  void setListener(Listener<MessageLite> listener) {
+  void setListener(RestateServerCallListener<MessageLite> listener) {
     this.listener = listener;
     this.listener.onReady();
 
@@ -158,8 +158,7 @@ class RestateServerCall extends ServerCall<MessageLite, MessageLite> {
                           MessageLite message = deferredValue.toReadyResult().getResult();
 
                           LOG.trace("Read input message:\n{}", message);
-                          listener.onMessage(message);
-                          listener.onHalfClose();
+                          listener.onMessageAndHalfClose(message);
                         },
                         this::onError)),
             this::onError));

--- a/sdk-core-impl/src/main/java/dev/restate/sdk/core/impl/RestateServerCallListener.java
+++ b/sdk-core-impl/src/main/java/dev/restate/sdk/core/impl/RestateServerCallListener.java
@@ -1,0 +1,18 @@
+package dev.restate.sdk.core.impl;
+
+/**
+ * Callbacks for incoming rpc messages.
+ *
+ * <p>This interface is strongly inspired by {@link io.grpc.ServerCall.Listener}.
+ *
+ * @param <M> type of the incoming message
+ */
+public interface RestateServerCallListener<M> {
+  void onMessageAndHalfClose(M message);
+
+  void onCancel();
+
+  void onComplete();
+
+  void onReady();
+}


### PR DESCRIPTION
This commit introduces the RestateServerCallListener interface that combines the ServerCall.Listener#onMessage and #onHalfClose calls into a single call so that we solve the race condition caused by the RestateServerCall that called these two methods separately.

This fixes #74.