### PR TITLE
Fix end span

### DIFF
--- a/sdk-core-impl/src/main/java/dev/restate/sdk/core/impl/InvocationStateMachine.java
+++ b/sdk-core-impl/src/main/java/dev/restate/sdk/core/impl/InvocationStateMachine.java
@@ -196,6 +196,7 @@ class InvocationStateMachine implements InvocationFlow.InvocationProcessor {
       this.readyResultPublisher.abort(ProtocolException.CLOSED);
       this.sideEffectAckPublisher.abort(ProtocolException.CLOSED);
       this.entriesQueue.abort(ProtocolException.CLOSED);
+      this.span.end();
     }
   }
 
@@ -214,6 +215,7 @@ class InvocationStateMachine implements InvocationFlow.InvocationProcessor {
       this.readyResultPublisher.abort(cause);
       this.sideEffectAckPublisher.abort(cause);
       this.entriesQueue.abort(cause);
+      this.span.end();
     }
   }
 


### PR DESCRIPTION
Without `span.end()`, the span is never committed.