### PR TITLE
Simpler error strategy

### DIFF
--- a/sdk-blocking/src/main/java/dev/restate/sdk/blocking/RestateBlockingService.java
+++ b/sdk-blocking/src/main/java/dev/restate/sdk/blocking/RestateBlockingService.java
@@ -3,7 +3,21 @@ package dev.restate.sdk.blocking;
 import dev.restate.sdk.core.BindableBlockingService;
 import dev.restate.sdk.core.syscalls.Syscalls;
 
-/** Marker interface for Restate blocking services. */
+/**
+ * Marker interface for Restate blocking services.
+ *
+ * <h3>Error handling</h3>
+ *
+ * The error handling of Restate services works as follows:
+ *
+ * <ul>
+ *   <li>When throwing {@link io.grpc.StatusException} or {@link io.grpc.StatusRuntimeException},
+ *       the failure is considered "terminal" and will be used as invocation output
+ *   <li>When throwing any other type of exception, the failure is considered "non-terminal" and the
+ *       runtime will retry it, according to its configuration
+ *   <li>In case {@code StreamObserver#onError} is invoked, the failure is considered "terminal"
+ * </ul>
+ */
 public interface RestateBlockingService extends BindableBlockingService {
 
   /**

--- a/sdk-core-impl/src/main/java/dev/restate/sdk/core/impl/GrpcServerCallListenerAdaptor.java
+++ b/sdk-core-impl/src/main/java/dev/restate/sdk/core/impl/GrpcServerCallListenerAdaptor.java
@@ -2,7 +2,6 @@ package dev.restate.sdk.core.impl;
 
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
-import io.grpc.Status;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -68,7 +67,7 @@ class GrpcServerCallListenerAdaptor<ReqT, RespT> implements RestateServerCallLis
       serverCall.close(Util.SUSPENDED_STATUS, new Metadata());
     } else {
       LOG.warn("Error when processing the invocation", e);
-      serverCall.close(Status.fromThrowable(e), new Metadata());
+      serverCall.close(Util.toGrpcStatusWrappingUncaught(e), new Metadata());
     }
   }
 }

--- a/sdk-core-impl/src/main/java/dev/restate/sdk/core/impl/RestateServerCall.java
+++ b/sdk-core-impl/src/main/java/dev/restate/sdk/core/impl/RestateServerCall.java
@@ -87,9 +87,9 @@ class RestateServerCall extends ServerCall<MessageLite, MessageLite> {
       // Let's cancel the listener first
       listener.onCancel();
 
-      if (status.getCode() == Status.Code.UNKNOWN) {
-        // If no cause, just propagate a generic runtime exception
-        syscalls.fail(status.getCause() != null ? status.getCause() : status.asRuntimeException());
+      if (status.getCause() instanceof UncaughtException) {
+        // This is the case where we have uncaught exceptions from GrpcServerCallListenerAdaptor
+        syscalls.fail(status.getCause().getCause());
       } else {
         syscalls.writeOutput(
             status.asRuntimeException(),

--- a/sdk-core-impl/src/main/java/dev/restate/sdk/core/impl/UncaughtException.java
+++ b/sdk-core-impl/src/main/java/dev/restate/sdk/core/impl/UncaughtException.java
@@ -1,0 +1,12 @@
+package dev.restate.sdk.core.impl;
+
+/**
+ * Just a marker exception used to mark an exception as uncaught in {@link
+ * GrpcServerCallListenerAdaptor}.
+ */
+class UncaughtException extends RuntimeException {
+
+  UncaughtException(Throwable t) {
+    super(t);
+  }
+}

--- a/sdk-core-impl/src/test/java/dev/restate/sdk/core/impl/UserFailuresTest.java
+++ b/sdk-core-impl/src/test/java/dev/restate/sdk/core/impl/UserFailuresTest.java
@@ -87,17 +87,6 @@ class UserFailuresTest extends CoreTestRunner {
             .withInput(startMessage(1), inputMessage(GreetingRequest.getDefaultInstance()))
             .usingAllThreadingModels()
             .assertingOutput(containsOnlyExactErrorMessage(new IllegalStateException("Whatever"))),
-        testInvocation(new ThrowUnknownStatusRuntimeException(), GreeterGrpc.getGreetMethod())
-            .withInput(startMessage(1), inputMessage(GreetingRequest.getDefaultInstance()))
-            .usingAllThreadingModels()
-            .assertingOutput(
-                containsOnlyExactErrorMessage(
-                    Status.UNKNOWN.withDescription("Whatever").asRuntimeException())),
-        testInvocation(
-                new ResponseObserverOnErrorIllegalStateException(), GreeterGrpc.getGreetMethod())
-            .withInput(startMessage(1), inputMessage(GreetingRequest.getDefaultInstance()))
-            .usingAllThreadingModels()
-            .assertingOutput(containsOnlyExactErrorMessage(new IllegalStateException("Whatever"))),
         testInvocation(new SideEffectThrowIllegalStateException(), GreeterGrpc.getGreetMethod())
             .withInput(startMessage(1), inputMessage(GreetingRequest.getDefaultInstance()))
             .usingAllThreadingModels()
@@ -108,11 +97,20 @@ class UserFailuresTest extends CoreTestRunner {
             .withInput(startMessage(1), inputMessage(GreetingRequest.getDefaultInstance()))
             .usingAllThreadingModels()
             .expectingOutput(outputMessage(MY_ERROR)),
+        testInvocation(new ThrowUnknownStatusRuntimeException(), GreeterGrpc.getGreetMethod())
+            .withInput(startMessage(1), inputMessage(GreetingRequest.getDefaultInstance()))
+            .usingAllThreadingModels()
+            .expectingOutput(outputMessage(Status.UNKNOWN.withDescription("Whatever"))),
         testInvocation(
                 new ResponseObserverOnErrorStatusRuntimeException(), GreeterGrpc.getGreetMethod())
             .withInput(startMessage(1), inputMessage(GreetingRequest.getDefaultInstance()))
             .usingAllThreadingModels()
             .expectingOutput(outputMessage(MY_ERROR)),
+        testInvocation(
+                new ResponseObserverOnErrorIllegalStateException(), GreeterGrpc.getGreetMethod())
+            .withInput(startMessage(1), inputMessage(GreetingRequest.getDefaultInstance()))
+            .usingAllThreadingModels()
+            .expectingOutput(outputMessage(Status.UNKNOWN)),
         testInvocation(new SideEffectThrowStatusRuntimeException(), GreeterGrpc.getGreetMethod())
             .withInput(startMessage(1), inputMessage(GreetingRequest.getDefaultInstance()))
             .usingAllThreadingModels()


### PR DESCRIPTION
Fix #101 

This implements a (IMO) simpler error strategy, less error prone:

*  Every `thrown` failure that is a `StatusRuntimeException` or a `StatusException`, or every failure passed to `StreamObserver#onError` is a terminal failure
*  In all the other cases is a non terminal failure

It adds a bit of "asymmetry" wrt the error types, due to `StreamObserver#onError`, but i believe this is fine, because the user intentionally calls `StreamObserver#onError` (as opposed to runtime exceptions that might just be thrown by 3rd party libraries)