### PR TITLE
Remove the future returned from RestateHttpEndpointBuilder

### DIFF
--- a/examples/http/src/main/java/dev/restate/sdk/examples/BlockingCounter.java
+++ b/examples/http/src/main/java/dev/restate/sdk/examples/BlockingCounter.java
@@ -7,7 +7,6 @@ import dev.restate.sdk.core.StateKey;
 import dev.restate.sdk.examples.generated.*;
 import dev.restate.sdk.vertx.RestateHttpEndpointBuilder;
 import io.grpc.stub.StreamObserver;
-import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -62,8 +61,6 @@ public class BlockingCounter extends CounterGrpc.CounterImplBase implements Rest
   }
 
   public static void main(String[] args) {
-    Vertx vertx = Vertx.vertx();
-
-    RestateHttpEndpointBuilder.builder(vertx).withService(new BlockingCounter()).buildAndListen();
+    RestateHttpEndpointBuilder.builder().withService(new BlockingCounter()).buildAndListen();
   }
 }

--- a/examples/http/src/main/kotlin/dev/restate/sdk/examples/Counter.kt
+++ b/examples/http/src/main/kotlin/dev/restate/sdk/examples/Counter.kt
@@ -56,7 +56,6 @@ class Counter(coroutineContext: CoroutineContext) :
 
 fun main() {
   val vertx = Vertx.vertx()
-
   RestateHttpEndpointBuilder.builder(vertx)
       .withService(Counter(coroutineContext = vertx.dispatcher()))
       .buildAndListen()


### PR DESCRIPTION
This way, you don't need the explicit vert.x dependency if you don't need to tune the http server configuration.