### PR TITLE
Modify SuspendedException to subclass Throwable rather than RuntimeException

### DIFF
--- a/sdk-core/src/main/java/dev/restate/sdk/core/SuspendedException.java
+++ b/sdk-core/src/main/java/dev/restate/sdk/core/SuspendedException.java
@@ -1,8 +1,13 @@
 package dev.restate.sdk.core;
 
-public final class SuspendedException extends RuntimeException {
+public final class SuspendedException extends Throwable {
   @SuppressWarnings("StaticAssignmentOfThrowable")
   public static final SuspendedException INSTANCE = new SuspendedException();
+
+  @SuppressWarnings("unchecked")
+  public static <E extends Throwable> void sneakyThrow() throws E {
+    throw (E) SuspendedException.INSTANCE;
+  }
 
   private SuspendedException() {
     super("SuspendedException");

--- a/sdk-java-blocking/src/main/java/dev/restate/sdk/blocking/Util.java
+++ b/sdk-java-blocking/src/main/java/dev/restate/sdk/blocking/Util.java
@@ -17,7 +17,8 @@ class Util {
     try {
       return future.get();
     } catch (InterruptedException | CancellationException e) {
-      throw SuspendedException.INSTANCE;
+      SuspendedException.sneakyThrow();
+      return null; // Previous statement throws an exception
     } catch (ExecutionException e) {
       throw (RuntimeException) e.getCause();
     }


### PR DESCRIPTION
With this change we can prototype a Channel implementation to reuse grpc code generated clients.