### PR TITLE
Jackson module discovery

### DIFF
--- a/sdk-serde-jackson/src/main/java/dev/restate/sdk/core/serde/jackson/CBORJacksonSerdeProvider.java
+++ b/sdk-serde-jackson/src/main/java/dev/restate/sdk/core/serde/jackson/CBORJacksonSerdeProvider.java
@@ -8,6 +8,9 @@ import dev.restate.sdk.core.serde.SerdeProvider;
 public class CBORJacksonSerdeProvider implements SerdeProvider {
   @Override
   public Serde create() {
-    return JacksonSerde.usingMapper(new ObjectMapper(new CBORFactory()));
+    ObjectMapper mapper = new ObjectMapper(new CBORFactory());
+    // Find modules through SPI (e.g. jackson-datatype-jsr310)
+    mapper.findAndRegisterModules();
+    return JacksonSerde.usingMapper(mapper);
   }
 }


### PR DESCRIPTION
Find Jackson modules through SPIs. This is useful for auto-discovering java8 modules: https://github.com/FasterXML/jackson-modules-java8#registering-modules