### PR TITLE
Add `InvocationStateMachine` state to logs context

### DIFF
--- a/examples/src/main/resources/log4j2.properties
+++ b/examples/src/main/resources/log4j2.properties
@@ -5,7 +5,7 @@ status = warn
 appender.console.type = Console
 appender.console.name = consoleLogger
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %notEmpty{[%X{restateServiceMethod}]}%notEmpty{[%X{restateInvocationId}]} %c - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %notEmpty{[%X{restateServiceMethod}]}%notEmpty{[%X{restateInvocationId}]}%notEmpty{[%X{restateInvocationStatus}]} %c - %m%n
 
 # Restate logs to debug level
 logger.app.name = dev.restate

--- a/sdk-core-impl/src/main/java/dev/restate/sdk/core/impl/RestateGrpcServer.java
+++ b/sdk-core-impl/src/main/java/dev/restate/sdk/core/impl/RestateGrpcServer.java
@@ -76,7 +76,9 @@ public class RestateGrpcServer {
     loggingContextSetter.setServiceMethod(serviceMethodName);
 
     // Instantiate state machine, syscall and grpc bridge
-    InvocationStateMachine stateMachine = new InvocationStateMachine(serviceName, span);
+    InvocationStateMachine stateMachine =
+        new InvocationStateMachine(
+            serviceName, span, s -> loggingContextSetter.setInvocationStatus(s.toString()));
     SyscallsInternal syscalls =
         syscallExecutor != null
             ? ExecutorSwitchingWrappers.syscalls(new SyscallsImpl(stateMachine), syscallExecutor)
@@ -190,6 +192,7 @@ public class RestateGrpcServer {
 
     String INVOCATION_ID_KEY = "restateInvocationId";
     String SERVICE_METHOD_KEY = "restateServiceMethod";
+    String SERVICE_INVOCATION_STATUS = "restateInvocationStatus";
 
     LoggingContextSetter THREAD_LOCAL_INSTANCE =
         new LoggingContextSetter() {
@@ -202,10 +205,17 @@ public class RestateGrpcServer {
           public void setInvocationId(String id) {
             ThreadContext.put(SERVICE_METHOD_KEY, id);
           }
+
+          @Override
+          public void setInvocationStatus(String invocationStatus) {
+            ThreadContext.put(SERVICE_INVOCATION_STATUS, invocationStatus);
+          }
         };
 
     void setServiceMethod(String serviceMethod);
 
     void setInvocationId(String id);
+
+    void setInvocationStatus(String invocationStatus);
   }
 }

--- a/sdk-http-vertx/src/main/java/dev/restate/sdk/http/vertx/RequestHttpServerHandler.java
+++ b/sdk-http-vertx/src/main/java/dev/restate/sdk/http/vertx/RequestHttpServerHandler.java
@@ -120,6 +120,13 @@ class RequestHttpServerHandler implements Handler<HttpServerRequest> {
                 public void setInvocationId(String id) {
                   ContextualData.put(RestateGrpcServer.LoggingContextSetter.INVOCATION_ID_KEY, id);
                 }
+
+                @Override
+                public void setInvocationStatus(String invocationStatus) {
+                  ContextualData.put(
+                      RestateGrpcServer.LoggingContextSetter.SERVICE_INVOCATION_STATUS,
+                      invocationStatus);
+                }
               },
               isBlockingService ? currentContextExecutor(vertxCurrentContext) : null,
               isBlockingService ? blockingExecutor(serviceName) : null);


### PR DESCRIPTION
This can be used for filtering using the log4j2 [`ContextMapFilter`](https://logging.apache.org/log4j/2.x/manual/filters.html#threadcontextmapfilter-or-contextmapfilter)