### PR TITLE
Improve documentation/names of marker interfaces

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,7 +113,7 @@ subprojects {
 
   val testReport =
       tasks.register<TestReport>("testReport") {
-        destinationDirectory.set(file("${layout.buildDirectory}/reports/tests/test"))
+        destinationDirectory.set(layout.buildDirectory.dir("reports/tests/test"))
         testResults.setFrom(subprojects.mapNotNull { it.tasks.findByPath("test") })
       }
 

--- a/examples/src/main/java/dev/restate/sdk/examples/VanillaGrpcCounter.java
+++ b/examples/src/main/java/dev/restate/sdk/examples/VanillaGrpcCounter.java
@@ -9,8 +9,8 @@
 package dev.restate.sdk.examples;
 
 import com.google.protobuf.Empty;
-import dev.restate.sdk.RestateBlockingService;
 import dev.restate.sdk.RestateContext;
+import dev.restate.sdk.RestateService;
 import dev.restate.sdk.common.CoreSerdes;
 import dev.restate.sdk.common.StateKey;
 import dev.restate.sdk.examples.generated.*;
@@ -19,8 +19,7 @@ import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class VanillaGrpcCounter extends CounterGrpc.CounterImplBase
-    implements RestateBlockingService {
+public class VanillaGrpcCounter extends CounterGrpc.CounterImplBase implements RestateService {
 
   private static final Logger LOG = LogManager.getLogger(VanillaGrpcCounter.class);
 

--- a/examples/src/main/kotlin/dev/restate/sdk/examples/CounterKt.kt
+++ b/examples/src/main/kotlin/dev/restate/sdk/examples/CounterKt.kt
@@ -13,12 +13,11 @@ import dev.restate.sdk.common.CoreSerdes
 import dev.restate.sdk.common.StateKey
 import dev.restate.sdk.examples.generated.*
 import dev.restate.sdk.http.vertx.RestateHttpEndpointBuilder
-import dev.restate.sdk.kotlin.RestateCoroutineService
+import dev.restate.sdk.kotlin.RestateKtService
 import kotlinx.coroutines.Dispatchers
 import org.apache.logging.log4j.LogManager
 
-class CounterKt :
-    CounterGrpcKt.CounterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+class CounterKt : CounterGrpcKt.CounterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
 
   private val LOG = LogManager.getLogger(CounterKt::class.java)
 

--- a/protoc-gen-restate/src/main/resources/blockingStub.mustache
+++ b/protoc-gen-restate/src/main/resources/blockingStub.mustache
@@ -93,7 +93,7 @@ public class {{className}} {
     }
 
 {{{javadoc}}}
-    public static abstract class {{serviceName}}RestateImplBase implements dev.restate.sdk.RestateBlockingService {
+    public static abstract class {{serviceName}}RestateImplBase implements dev.restate.sdk.RestateService {
 
         {{#methods}}
         {{#deprecated}}

--- a/sdk-api-kotlin/src/main/kotlin/dev/restate/sdk/kotlin/api.kt
+++ b/sdk-api-kotlin/src/main/kotlin/dev/restate/sdk/kotlin/api.kt
@@ -8,8 +8,8 @@
 // https://github.com/restatedev/sdk-java/blob/main/LICENSE
 package dev.restate.sdk.kotlin
 
-import dev.restate.sdk.common.BindableNonBlockingService
 import dev.restate.sdk.common.CoreSerdes
+import dev.restate.sdk.common.NonBlockingService
 import dev.restate.sdk.common.Serde
 import dev.restate.sdk.common.StateKey
 import dev.restate.sdk.common.syscalls.Syscalls
@@ -22,8 +22,8 @@ import kotlin.time.Duration
  * the service instance key-value state storage, interact with other Restate services, record side
  * effects, execute timers and synchronize with external systems.
  *
- * To use it within your Restate service, implement [RestateCoroutineService] and get an instance
- * with [RestateCoroutineService.restateContext].
+ * To use it within your Restate service, implement [RestateKtService] and get an instance with
+ * [RestateKtService.restateContext].
  *
  * All methods of this interface, and related interfaces, throws either [TerminalException] or
  * cancels the coroutine. [TerminalException] can be caught and acted upon.
@@ -328,8 +328,18 @@ sealed interface AwakeableHandle {
   suspend fun reject(reason: String)
 }
 
-/** Marker interface for Kotlin Restate coroutine services. */
-interface RestateCoroutineService : BindableNonBlockingService {
+/**
+ * Marker interface for Restate services implemented using the [RestateContext] interface.
+ *
+ * ## Error handling
+ *
+ * The error handling of Restate services works as follows:
+ * * When throwing {@link TerminalException}, the failure will be used as invocation response error
+ *   value
+ * * When throwing any other type of exception, the failure is considered "non-terminal" and the
+ *   runtime will retry it, according to its configuration
+ */
+interface RestateKtService : NonBlockingService {
   /** @return an instance of the [RestateContext]. */
   fun restateContext(): RestateContext {
     return RestateContextImpl(Syscalls.SYSCALLS_KEY.get())

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/AwakeableIdTest.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/AwakeableIdTest.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.Dispatchers
 
 class AwakeableIdTest : AwakeableIdTestSuite() {
   private class ReturnAwakeableId :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
 
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val id: String = restateContext().awakeable(CoreSerdes.STRING_UTF8).id

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/DeferredTest.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/DeferredTest.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.Dispatchers
 
 class DeferredTest : DeferredTestSuite() {
   private class ReverseAwaitOrder :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
       val a1 = ctx.callAsync(GreeterGrpcKt.greetMethod, greetingRequest { name = "Francesco" })
@@ -36,7 +36,7 @@ class DeferredTest : DeferredTestSuite() {
   }
 
   private class AwaitTwiceTheSameAwaitable :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
       val a = ctx.callAsync(GreeterGrpcKt.greetMethod, greetingRequest { name = "Francesco" })
@@ -49,7 +49,7 @@ class DeferredTest : DeferredTestSuite() {
   }
 
   private class AwaitAll :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
       val a1 = ctx.callAsync(GreeterGrpcKt.greetMethod, greetingRequest { name = "Francesco" })
@@ -69,7 +69,7 @@ class DeferredTest : DeferredTestSuite() {
   }
 
   private class AwaitAny :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
       val a1 = ctx.callAsync(GreeterGrpcKt.greetMethod, greetingRequest { name = "Francesco" })
@@ -79,7 +79,7 @@ class DeferredTest : DeferredTestSuite() {
   }
 
   private class AwaitSelect :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
       val a1 = ctx.callAsync(GreeterGrpcKt.greetMethod, greetingRequest { name = "Francesco" })
@@ -96,7 +96,7 @@ class DeferredTest : DeferredTestSuite() {
   }
 
   private class CombineAnyWithAll :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
       val a1 = ctx.awakeable(CoreSerdes.STRING_UTF8)
@@ -119,7 +119,7 @@ class DeferredTest : DeferredTestSuite() {
   }
 
   private class AwaitAnyIndex :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
       val a1 = ctx.awakeable(CoreSerdes.STRING_UTF8)
@@ -138,7 +138,7 @@ class DeferredTest : DeferredTestSuite() {
   }
 
   private class AwaitOnAlreadyResolvedAwaitables :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
       val a1 = ctx.awakeable(CoreSerdes.STRING_UTF8)

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/EagerStateTest.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/EagerStateTest.kt
@@ -21,7 +21,7 @@ import org.assertj.core.api.AssertionsForClassTypes.assertThat
 
 class EagerStateTest : EagerStateTestSuite() {
   private class GetEmpty :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
       val stateIsEmpty = ctx.get(StateKey.of("STATE", CoreSerdes.STRING_UTF8)) == null
@@ -34,7 +34,7 @@ class EagerStateTest : EagerStateTestSuite() {
   }
 
   private class Get :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       return greetingResponse {
         message = restateContext().get(StateKey.of("STATE", CoreSerdes.STRING_UTF8))!!
@@ -47,7 +47,7 @@ class EagerStateTest : EagerStateTestSuite() {
   }
 
   private class GetAppendAndGet :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
       val oldState = ctx.get(StateKey.of("STATE", CoreSerdes.STRING_UTF8))!!
@@ -62,7 +62,7 @@ class EagerStateTest : EagerStateTestSuite() {
   }
 
   private class GetClearAndGet :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
       val oldState = ctx.get(StateKey.of("STATE", CoreSerdes.STRING_UTF8))!!

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/InvocationIdTest.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/InvocationIdTest.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.Dispatchers
 
 class InvocationIdTest : InvocationIdTestSuite() {
   private class ReturnInvocationId :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       return greetingResponse { message = InvocationId.current().toString() }
     }

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/OnlyInputAndOutputTest.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/OnlyInputAndOutputTest.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.Dispatchers
 
 class OnlyInputAndOutputTest : OnlyInputAndOutputTestSuite() {
   private class NoSyscallsGreeter :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       return greetingResponse { message = "Hello " + request.getName() }
     }

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/SideEffectTest.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/SideEffectTest.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.Dispatchers
 
 class SideEffectTest : SideEffectTestSuite() {
   private class SideEffect(private val sideEffectOutput: String) :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx: RestateContext = restateContext()
       val result = ctx.sideEffect(CoreSerdes.STRING_UTF8) { sideEffectOutput }
@@ -31,7 +31,7 @@ class SideEffectTest : SideEffectTestSuite() {
   }
 
   private class ConsecutiveSideEffect(private val sideEffectOutput: String) :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx: RestateContext = restateContext()
       val firstResult = ctx.sideEffect(CoreSerdes.STRING_UTF8) { sideEffectOutput }
@@ -48,7 +48,7 @@ class SideEffectTest : SideEffectTestSuite() {
   private class CheckContextSwitching :
       GreeterGrpcKt.GreeterCoroutineImplBase(
           Dispatchers.Unconfined + CoroutineName("CheckContextSwitchingTestCoroutine")),
-      RestateCoroutineService {
+      RestateKtService {
 
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val sideEffectThread =
@@ -65,7 +65,7 @@ class SideEffectTest : SideEffectTestSuite() {
   }
 
   private class SideEffectGuard :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
       ctx.sideEffect {

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/SleepTest.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/SleepTest.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.Dispatchers
 
 class SleepTest : SleepTestSuite() {
   private class SleepGreeter :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
       ctx.sleep(1000.milliseconds)
@@ -32,7 +32,7 @@ class SleepTest : SleepTestSuite() {
   }
 
   private class ManySleeps :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
       val awaitables = mutableListOf<Awaitable<Unit>>()

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/StateMachineFailuresTest.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/StateMachineFailuresTest.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.Dispatchers
 
 class StateMachineFailuresTest : StateMachineFailuresTestSuite() {
   private class GetState(private val nonTerminalExceptionsSeen: AtomicInteger) :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       try {
         restateContext().get(STATE)
@@ -55,7 +55,7 @@ class StateMachineFailuresTest : StateMachineFailuresTestSuite() {
   }
 
   private class SideEffectFailure(private val serde: Serde<Int>) :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       restateContext().sideEffect(serde) { 0 }
       return greetingResponse { message = "Francesco" }

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/StateTest.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/StateTest.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.Dispatchers
 
 class StateTest : StateTestSuite() {
   private class GetState :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val state: String =
           restateContext().get(StateKey.of("STATE", CoreSerdes.STRING_UTF8)) ?: "Unknown"
@@ -33,7 +33,7 @@ class StateTest : StateTestSuite() {
   }
 
   private class GetAndSetState :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       val ctx = restateContext()
 

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/UserFailuresTest.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/UserFailuresTest.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.Dispatchers
 
 class UserFailuresTest : UserFailuresTestSuite() {
   private class ThrowIllegalStateException :
-      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       throw IllegalStateException("Whatever")
     }
@@ -32,7 +32,7 @@ class UserFailuresTest : UserFailuresTestSuite() {
 
   private class SideEffectThrowIllegalStateException(
       private val nonTerminalExceptionsSeen: AtomicInteger
-  ) : GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+  ) : GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       try {
         restateContext().sideEffect { throw IllegalStateException("Whatever") }
@@ -56,7 +56,7 @@ class UserFailuresTest : UserFailuresTestSuite() {
   private class ThrowTerminalException(
       private val code: TerminalException.Code,
       private val message: String
-  ) : GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+  ) : GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       throw TerminalException(code, message)
     }
@@ -72,7 +72,7 @@ class UserFailuresTest : UserFailuresTestSuite() {
   private class SideEffectThrowTerminalException(
       private val code: TerminalException.Code,
       private val message: String
-  ) : GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateCoroutineService {
+  ) : GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
     override suspend fun greet(request: GreetingRequest): GreetingResponse {
       restateContext().sideEffect { throw TerminalException(code, message) }
       throw IllegalStateException("Not expected to reach this point")

--- a/sdk-api/src/main/java/dev/restate/sdk/RestateContext.java
+++ b/sdk-api/src/main/java/dev/restate/sdk/RestateContext.java
@@ -24,8 +24,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  * the service instance key-value state storage, interact with other Restate services, record side
  * effects, execute timers and synchronize with external systems.
  *
- * <p>To use it within your Restate service, implement {@link RestateBlockingService} and get an
- * instance with {@link RestateBlockingService#restateContext()}.
+ * <p>To use it within your Restate service, implement {@link RestateService} and get an instance
+ * with {@link RestateService#restateContext()}.
  *
  * <p>All methods of this interface, and related interfaces, throws either {@link TerminalException}
  * or {@link AbortedExecutionException}, where the former can be caught and acted upon, while the
@@ -211,7 +211,7 @@ public interface RestateContext {
    * Build a RestateContext from the underlying {@link Syscalls} object.
    *
    * <p>This method is used by code-generation, you should not use it directly but rather use {@link
-   * RestateBlockingService#restateContext()}.
+   * RestateService#restateContext()}.
    */
   static RestateContext fromSyscalls(Syscalls syscalls) {
     return new RestateContextImpl(syscalls);

--- a/sdk-api/src/main/java/dev/restate/sdk/RestateService.java
+++ b/sdk-api/src/main/java/dev/restate/sdk/RestateService.java
@@ -8,12 +8,12 @@
 // https://github.com/restatedev/sdk-java/blob/main/LICENSE
 package dev.restate.sdk;
 
-import dev.restate.sdk.common.BindableBlockingService;
+import dev.restate.sdk.common.BlockingService;
 import dev.restate.sdk.common.TerminalException;
 import dev.restate.sdk.common.syscalls.Syscalls;
 
 /**
- * Marker interface for Restate blocking services.
+ * Marker interface for Restate services implemented using the {@link RestateContext} interface.
  *
  * <p>
  *
@@ -28,7 +28,7 @@ import dev.restate.sdk.common.syscalls.Syscalls;
  *       runtime will retry it, according to its configuration
  * </ul>
  */
-public interface RestateBlockingService extends BindableBlockingService {
+public interface RestateService extends BlockingService {
 
   /**
    * @return an instance of the {@link RestateContext}.

--- a/sdk-api/src/test/java/dev/restate/sdk/AwakeableIdTest.java
+++ b/sdk-api/src/test/java/dev/restate/sdk/AwakeableIdTest.java
@@ -21,7 +21,7 @@ import io.grpc.stub.StreamObserver;
 public class AwakeableIdTest extends AwakeableIdTestSuite {
 
   private static class ReturnAwakeableId extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
 
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {

--- a/sdk-api/src/test/java/dev/restate/sdk/DeferredTest.java
+++ b/sdk-api/src/test/java/dev/restate/sdk/DeferredTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeoutException;
 public class DeferredTest extends DeferredTestSuite {
 
   private static class ReverseAwaitOrder extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();
@@ -51,7 +51,7 @@ public class DeferredTest extends DeferredTestSuite {
   }
 
   private static class AwaitTwiceTheSameAwaitable extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();
@@ -70,8 +70,7 @@ public class DeferredTest extends DeferredTestSuite {
     return new AwaitTwiceTheSameAwaitable();
   }
 
-  private static class AwaitAll extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+  private static class AwaitAll extends GreeterGrpc.GreeterImplBase implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();
@@ -94,8 +93,7 @@ public class DeferredTest extends DeferredTestSuite {
     return new AwaitAll();
   }
 
-  private static class AwaitAny extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+  private static class AwaitAny extends GreeterGrpc.GreeterImplBase implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();
@@ -118,7 +116,7 @@ public class DeferredTest extends DeferredTestSuite {
   }
 
   private static class CombineAnyWithAll extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();
@@ -143,8 +141,7 @@ public class DeferredTest extends DeferredTestSuite {
     return new CombineAnyWithAll();
   }
 
-  private static class AwaitAnyIndex extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+  private static class AwaitAnyIndex extends GreeterGrpc.GreeterImplBase implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();
@@ -167,7 +164,7 @@ public class DeferredTest extends DeferredTestSuite {
   }
 
   private static class AwaitOnAlreadyResolvedAwaitables extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();
@@ -193,7 +190,7 @@ public class DeferredTest extends DeferredTestSuite {
   }
 
   private static class AwaitWithTimeout extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();

--- a/sdk-api/src/test/java/dev/restate/sdk/EagerStateTest.java
+++ b/sdk-api/src/test/java/dev/restate/sdk/EagerStateTest.java
@@ -21,8 +21,7 @@ import io.grpc.stub.StreamObserver;
 
 public class EagerStateTest extends EagerStateTestSuite {
 
-  private static class GetEmpty extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+  private static class GetEmpty extends GreeterGrpc.GreeterImplBase implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();
@@ -40,7 +39,7 @@ public class EagerStateTest extends EagerStateTestSuite {
     return new GetEmpty();
   }
 
-  private static class Get extends GreeterGrpc.GreeterImplBase implements RestateBlockingService {
+  private static class Get extends GreeterGrpc.GreeterImplBase implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();
@@ -58,7 +57,7 @@ public class EagerStateTest extends EagerStateTestSuite {
   }
 
   private static class GetAppendAndGet extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();
@@ -79,7 +78,7 @@ public class EagerStateTest extends EagerStateTestSuite {
   }
 
   private static class GetClearAndGet extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();

--- a/sdk-api/src/test/java/dev/restate/sdk/GrpcChannelAdapterTest.java
+++ b/sdk-api/src/test/java/dev/restate/sdk/GrpcChannelAdapterTest.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 public class GrpcChannelAdapterTest implements TestSuite {
 
   private static class InvokeUsingGeneratedClient extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();
@@ -38,7 +38,7 @@ public class GrpcChannelAdapterTest implements TestSuite {
   }
 
   private static class InvokeUsingGeneratedFutureClient extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();

--- a/sdk-api/src/test/java/dev/restate/sdk/InvocationIdTest.java
+++ b/sdk-api/src/test/java/dev/restate/sdk/InvocationIdTest.java
@@ -21,7 +21,7 @@ import io.grpc.stub.StreamObserver;
 public class InvocationIdTest extends InvocationIdTestSuite {
 
   private static class ReturnInvocationId extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
 
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {

--- a/sdk-api/src/test/java/dev/restate/sdk/OnlyInputAndOutputTest.java
+++ b/sdk-api/src/test/java/dev/restate/sdk/OnlyInputAndOutputTest.java
@@ -18,7 +18,7 @@ import io.grpc.stub.StreamObserver;
 public class OnlyInputAndOutputTest extends OnlyInputAndOutputTestSuite {
 
   private static class NoSyscallsGreeter extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       responseObserver.onNext(

--- a/sdk-api/src/test/java/dev/restate/sdk/SideEffectTest.java
+++ b/sdk-api/src/test/java/dev/restate/sdk/SideEffectTest.java
@@ -21,8 +21,7 @@ import java.util.Objects;
 
 public class SideEffectTest extends SideEffectTestSuite {
 
-  private static class SideEffect extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+  private static class SideEffect extends GreeterGrpc.GreeterImplBase implements RestateService {
 
     private final String sideEffectOutput;
 
@@ -47,7 +46,7 @@ public class SideEffectTest extends SideEffectTestSuite {
   }
 
   private static class ConsecutiveSideEffect extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
 
     private final String sideEffectOutput;
 
@@ -74,7 +73,7 @@ public class SideEffectTest extends SideEffectTestSuite {
   }
 
   private static class CheckContextSwitching extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
 
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
@@ -103,7 +102,7 @@ public class SideEffectTest extends SideEffectTestSuite {
   }
 
   private static class SideEffectGuard extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
 
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {

--- a/sdk-api/src/test/java/dev/restate/sdk/SleepTest.java
+++ b/sdk-api/src/test/java/dev/restate/sdk/SleepTest.java
@@ -20,8 +20,7 @@ import java.util.List;
 
 public class SleepTest extends SleepTestSuite {
 
-  private static class SleepGreeter extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+  private static class SleepGreeter extends GreeterGrpc.GreeterImplBase implements RestateService {
 
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
@@ -39,8 +38,7 @@ public class SleepTest extends SleepTestSuite {
     return new SleepGreeter();
   }
 
-  private static class ManySleeps extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+  private static class ManySleeps extends GreeterGrpc.GreeterImplBase implements RestateService {
 
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {

--- a/sdk-api/src/test/java/dev/restate/sdk/StateMachineFailuresTest.java
+++ b/sdk-api/src/test/java/dev/restate/sdk/StateMachineFailuresTest.java
@@ -25,8 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class StateMachineFailuresTest extends StateMachineFailuresTestSuite {
 
-  private static class GetState extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+  private static class GetState extends GreeterGrpc.GreeterImplBase implements RestateService {
 
     private static final StateKey<Integer> STATE =
         StateKey.of(
@@ -67,7 +66,7 @@ public class StateMachineFailuresTest extends StateMachineFailuresTestSuite {
   }
 
   private static class SideEffectFailure extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
     private final Serde<Integer> serde;
 
     private SideEffectFailure(Serde<Integer> serde) {

--- a/sdk-api/src/test/java/dev/restate/sdk/StateTest.java
+++ b/sdk-api/src/test/java/dev/restate/sdk/StateTest.java
@@ -22,8 +22,7 @@ import io.grpc.stub.StreamObserver;
 
 public class StateTest extends StateTestSuite {
 
-  private static class GetState extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+  private static class GetState extends GreeterGrpc.GreeterImplBase implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       String state =
@@ -40,7 +39,7 @@ public class StateTest extends StateTestSuite {
   }
 
   private static class GetAndSetState extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       RestateContext ctx = restateContext();
@@ -59,8 +58,7 @@ public class StateTest extends StateTestSuite {
     return new GetAndSetState();
   }
 
-  private static class SetNullState extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+  private static class SetNullState extends GreeterGrpc.GreeterImplBase implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       restateContext()

--- a/sdk-api/src/test/java/dev/restate/sdk/UserFailuresTest.java
+++ b/sdk-api/src/test/java/dev/restate/sdk/UserFailuresTest.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 public class UserFailuresTest extends UserFailuresTestSuite {
 
   private static class ThrowIllegalStateException extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       throw new IllegalStateException("Whatever");
@@ -40,7 +40,7 @@ public class UserFailuresTest extends UserFailuresTestSuite {
   }
 
   private static class SideEffectThrowIllegalStateException extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
 
     private final AtomicInteger nonTerminalExceptionsSeen;
 
@@ -76,7 +76,7 @@ public class UserFailuresTest extends UserFailuresTestSuite {
   }
 
   private static class ThrowTerminalException extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
 
     private final TerminalException.Code code;
     private final String message;
@@ -98,7 +98,7 @@ public class UserFailuresTest extends UserFailuresTestSuite {
   }
 
   private static class SideEffectThrowTerminalException extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
 
     private final TerminalException.Code code;
     private final String message;
@@ -127,7 +127,7 @@ public class UserFailuresTest extends UserFailuresTestSuite {
   // -- Response observer is something specific to the sdk-java interface
 
   private static class ResponseObserverOnErrorTerminalException extends GreeterGrpc.GreeterImplBase
-      implements RestateBlockingService {
+      implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       responseObserver.onError(new TerminalException(TerminalException.Code.INTERNAL, MY_ERROR));
@@ -135,7 +135,7 @@ public class UserFailuresTest extends UserFailuresTestSuite {
   }
 
   private static class ResponseObserverOnErrorIllegalStateException
-      extends GreeterGrpc.GreeterImplBase implements RestateBlockingService {
+      extends GreeterGrpc.GreeterImplBase implements RestateService {
     @Override
     public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
       responseObserver.onError(new IllegalStateException("Whatever"));

--- a/sdk-common/src/main/java/dev/restate/sdk/common/BlockingService.java
+++ b/sdk-common/src/main/java/dev/restate/sdk/common/BlockingService.java
@@ -1,0 +1,16 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate Java SDK,
+// which is released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/sdk-java/blob/main/LICENSE
+package dev.restate.sdk.common;
+
+/**
+ * Marker interface for blocking services. This is used by some service endpoint implementations
+ * (like http-vertx) to select on which executor/context the service code should be executed. Refer
+ * to the *EndpointBuilder javadocs for more details.
+ */
+public interface BlockingService extends Service {}

--- a/sdk-common/src/main/java/dev/restate/sdk/common/NonBlockingService.java
+++ b/sdk-common/src/main/java/dev/restate/sdk/common/NonBlockingService.java
@@ -8,6 +8,9 @@
 // https://github.com/restatedev/sdk-java/blob/main/LICENSE
 package dev.restate.sdk.common;
 
-import io.grpc.BindableService;
-
-public interface BindableNonBlockingService extends BindableService {}
+/**
+ * Marker interface for non-blocking services. This is used by some service endpoint implementations
+ * (like http-vertx) to select on which executor/context the service code should be executed. Refer
+ * to the *EndpointBuilder javadocs for more details.
+ */
+public interface NonBlockingService extends Service {}

--- a/sdk-common/src/main/java/dev/restate/sdk/common/Service.java
+++ b/sdk-common/src/main/java/dev/restate/sdk/common/Service.java
@@ -10,4 +10,5 @@ package dev.restate.sdk.common;
 
 import io.grpc.BindableService;
 
-public interface BindableBlockingService extends BindableService {}
+/** Marker interface for a Restate service. */
+public interface Service extends BindableService {}

--- a/sdk-http-vertx/src/main/java/dev/restate/sdk/http/vertx/RestateHttpEndpointBuilder.java
+++ b/sdk-http-vertx/src/main/java/dev/restate/sdk/http/vertx/RestateHttpEndpointBuilder.java
@@ -9,8 +9,8 @@
 package dev.restate.sdk.http.vertx;
 
 import dev.restate.generated.service.discovery.Discovery;
-import dev.restate.sdk.common.BindableBlockingService;
-import dev.restate.sdk.common.BindableNonBlockingService;
+import dev.restate.sdk.common.BlockingService;
+import dev.restate.sdk.common.NonBlockingService;
 import dev.restate.sdk.core.RestateGrpcServer;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
@@ -76,26 +76,26 @@ public class RestateHttpEndpointBuilder {
   }
 
   /**
-   * Add a {@link BindableBlockingService} to the endpoint.
+   * Add a {@link BlockingService} to the endpoint.
    *
    * <p>NOTE: The service code will run within the Vert.x worker thread pool. For more details,
    * check the <a href="https://vertx.io/docs/vertx-core/java/#blocking_code">Vert.x
    * documentation</a>.
    */
   public RestateHttpEndpointBuilder withService(
-      BindableBlockingService service, ServerInterceptor... interceptors) {
+      BlockingService service, ServerInterceptor... interceptors) {
     return this.withService(service, defaultExecutor, interceptors);
   }
 
   /**
-   * Add a {@link BindableBlockingService} to the endpoint, specifying the {@code executor} where to
-   * run the service code.
+   * Add a {@link BlockingService} to the endpoint, specifying the {@code executor} where to run the
+   * service code.
    *
    * <p>You can run on virtual threads by using the executor {@code
    * Executors.newVirtualThreadPerTaskExecutor()}.
    */
   public RestateHttpEndpointBuilder withService(
-      BindableBlockingService service, Executor executor, ServerInterceptor... interceptors) {
+      BlockingService service, Executor executor, ServerInterceptor... interceptors) {
     ServerServiceDefinition definition =
         ServerInterceptors.intercept(service, Arrays.asList(interceptors));
     this.restateGrpcServerBuilder.withService(definition);
@@ -104,14 +104,14 @@ public class RestateHttpEndpointBuilder {
   }
 
   /**
-   * Add a {@link BindableNonBlockingService} to the endpoint.
+   * Add a {@link NonBlockingService} to the endpoint.
    *
    * <p>NOTE: The service code will run within the same Vert.x event loop thread handling the HTTP
    * stream, hence the code should never block the thread. For more details, check the <a
    * href="https://vertx.io/docs/vertx-core/java/#golden_rule">Vert.x documentation</a>.
    */
   public RestateHttpEndpointBuilder withService(
-      BindableNonBlockingService service, ServerInterceptor... interceptors) {
+      NonBlockingService service, ServerInterceptor... interceptors) {
     this.restateGrpcServerBuilder.withService(
         ServerInterceptors.intercept(service, Arrays.asList(interceptors)));
     return this;

--- a/sdk-http-vertx/src/test/java/dev/restate/sdk/http/vertx/testservices/BlockingGreeterService.java
+++ b/sdk-http-vertx/src/test/java/dev/restate/sdk/http/vertx/testservices/BlockingGreeterService.java
@@ -8,7 +8,7 @@
 // https://github.com/restatedev/sdk-java/blob/main/LICENSE
 package dev.restate.sdk.http.vertx.testservices;
 
-import dev.restate.sdk.RestateBlockingService;
+import dev.restate.sdk.RestateService;
 import dev.restate.sdk.common.Serde;
 import dev.restate.sdk.common.StateKey;
 import dev.restate.sdk.core.testservices.GreeterGrpc;
@@ -20,8 +20,7 @@ import java.time.Duration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class BlockingGreeterService extends GreeterGrpc.GreeterImplBase
-    implements RestateBlockingService {
+public class BlockingGreeterService extends GreeterGrpc.GreeterImplBase implements RestateService {
 
   private static final Logger LOG = LogManager.getLogger(BlockingGreeterService.class);
   public static final StateKey<Long> COUNTER =

--- a/sdk-http-vertx/src/test/kotlin/dev/restate/sdk/http/vertx/HttpVertxTestExecutor.kt
+++ b/sdk-http-vertx/src/test/kotlin/dev/restate/sdk/http/vertx/HttpVertxTestExecutor.kt
@@ -9,8 +9,8 @@
 package dev.restate.sdk.http.vertx
 
 import com.google.protobuf.MessageLite
-import dev.restate.sdk.common.BindableBlockingService
-import dev.restate.sdk.common.BindableNonBlockingService
+import dev.restate.sdk.common.BlockingService
+import dev.restate.sdk.common.NonBlockingService
 import dev.restate.sdk.core.TestDefinitions.TestDefinition
 import dev.restate.sdk.core.TestDefinitions.TestExecutor
 import io.vertx.core.Vertx
@@ -38,11 +38,11 @@ class HttpVertxTestExecutor(private val vertx: Vertx) : TestExecutor {
       val builder =
           RestateHttpEndpointBuilder.builder(vertx).withOptions(HttpServerOptions().setPort(0))
       when (definition.service) {
-        is BindableBlockingService -> {
-          builder.withService(definition.service as BindableBlockingService)
+        is BlockingService -> {
+          builder.withService(definition.service as BlockingService)
         }
-        is BindableNonBlockingService -> {
-          builder.withService(definition.service as BindableNonBlockingService)
+        is NonBlockingService -> {
+          builder.withService(definition.service as NonBlockingService)
         }
         else -> {
           throw IllegalStateException("Unexpected service class " + definition.service)

--- a/sdk-http-vertx/src/test/kotlin/dev/restate/sdk/http/vertx/HttpVertxTests.kt
+++ b/sdk-http-vertx/src/test/kotlin/dev/restate/sdk/http/vertx/HttpVertxTests.kt
@@ -13,12 +13,7 @@ import dev.restate.generated.sdk.java.Java.SideEffectEntryMessage
 import dev.restate.sdk.*
 import dev.restate.sdk.core.ProtoUtils.*
 import dev.restate.sdk.core.TestDefinitions.*
-import dev.restate.sdk.core.TestRunner
-import dev.restate.sdk.core.testservices.GreeterGrpc
-import dev.restate.sdk.core.testservices.GreeterGrpcKt
-import dev.restate.sdk.core.testservices.GreetingRequest
-import dev.restate.sdk.core.testservices.GreetingResponse
-import dev.restate.sdk.kotlin.RestateCoroutineService
+import dev.restate.sdk.kotlin.RestateKtService
 import io.grpc.stub.StreamObserver
 import io.vertx.core.Vertx
 import java.util.stream.Stream
@@ -48,7 +43,7 @@ class HttpVertxTests : dev.restate.sdk.core.TestRunner() {
     private class CheckNonBlockingServiceTrampolineEventLoopContext :
         dev.restate.sdk.core.testservices.GreeterGrpcKt.GreeterCoroutineImplBase(
             Dispatchers.Unconfined),
-        RestateCoroutineService {
+        RestateKtService {
       override suspend fun greet(
           request: dev.restate.sdk.core.testservices.GreetingRequest
       ): dev.restate.sdk.core.testservices.GreetingResponse {
@@ -60,7 +55,7 @@ class HttpVertxTests : dev.restate.sdk.core.TestRunner() {
     }
 
     private class CheckBlockingServiceTrampolineExecutor :
-        dev.restate.sdk.core.testservices.GreeterGrpc.GreeterImplBase(), RestateBlockingService {
+        dev.restate.sdk.core.testservices.GreeterGrpc.GreeterImplBase(), RestateService {
       override fun greet(
           request: dev.restate.sdk.core.testservices.GreetingRequest,
           responseObserver: StreamObserver<dev.restate.sdk.core.testservices.GreetingResponse>

--- a/sdk-http-vertx/src/test/kotlin/dev/restate/sdk/http/vertx/testservices/GreeterKtService.kt
+++ b/sdk-http-vertx/src/test/kotlin/dev/restate/sdk/http/vertx/testservices/GreeterKtService.kt
@@ -12,13 +12,13 @@ import dev.restate.sdk.core.testservices.GreeterGrpcKt
 import dev.restate.sdk.core.testservices.GreetingRequest
 import dev.restate.sdk.core.testservices.GreetingResponse
 import dev.restate.sdk.core.testservices.greetingResponse
-import dev.restate.sdk.kotlin.RestateCoroutineService
+import dev.restate.sdk.kotlin.RestateKtService
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.seconds
 import org.apache.logging.log4j.LogManager
 
 class GreeterKtService(coroutineContext: CoroutineContext) :
-    GreeterGrpcKt.GreeterCoroutineImplBase(coroutineContext), RestateCoroutineService {
+    GreeterGrpcKt.GreeterCoroutineImplBase(coroutineContext), RestateKtService {
 
   private val LOG = LogManager.getLogger(GreeterKtService::class.java)
 

--- a/sdk-lambda/src/main/java/dev/restate/sdk/lambda/RestateLambdaEndpointBuilder.java
+++ b/sdk-lambda/src/main/java/dev/restate/sdk/lambda/RestateLambdaEndpointBuilder.java
@@ -9,8 +9,7 @@
 package dev.restate.sdk.lambda;
 
 import dev.restate.generated.service.discovery.Discovery;
-import dev.restate.sdk.common.BindableBlockingService;
-import dev.restate.sdk.common.BindableNonBlockingService;
+import dev.restate.sdk.common.Service;
 import dev.restate.sdk.core.RestateGrpcServer;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
@@ -25,18 +24,13 @@ public final class RestateLambdaEndpointBuilder {
       RestateGrpcServer.newBuilder(Discovery.ProtocolMode.REQUEST_RESPONSE);
   private OpenTelemetry openTelemetry = OpenTelemetry.noop();
 
-  /** Add a {@link BindableBlockingService} to the endpoint. */
+  /**
+   * Add a {@link Service} to the endpoint.
+   *
+   * <p>The service code will be executed on the same thread where the lambda is invoked.
+   */
   public RestateLambdaEndpointBuilder withService(
-      BindableBlockingService service, ServerInterceptor... interceptors) {
-    ServerServiceDefinition definition =
-        ServerInterceptors.intercept(service, Arrays.asList(interceptors));
-    this.restateGrpcServerBuilder.withService(definition);
-    return this;
-  }
-
-  /** Add a {@link BindableNonBlockingService} to the endpoint. */
-  public RestateLambdaEndpointBuilder withService(
-      BindableNonBlockingService service, ServerInterceptor... interceptors) {
+      Service service, ServerInterceptor... interceptors) {
     ServerServiceDefinition definition =
         ServerInterceptors.intercept(service, Arrays.asList(interceptors));
     this.restateGrpcServerBuilder.withService(definition);

--- a/sdk-lambda/src/test/java/dev/restate/sdk/lambda/testservices/JavaCounterService.java
+++ b/sdk-lambda/src/test/java/dev/restate/sdk/lambda/testservices/JavaCounterService.java
@@ -8,14 +8,14 @@
 // https://github.com/restatedev/sdk-java/blob/main/LICENSE
 package dev.restate.sdk.lambda.testservices;
 
-import dev.restate.sdk.RestateBlockingService;
+import dev.restate.sdk.RestateService;
 import dev.restate.sdk.common.Serde;
 import dev.restate.sdk.common.StateKey;
 import io.grpc.stub.StreamObserver;
 import java.nio.charset.StandardCharsets;
 
 public class JavaCounterService extends JavaCounterGrpc.JavaCounterImplBase
-    implements RestateBlockingService {
+    implements RestateService {
 
   public static final StateKey<Long> COUNTER =
       StateKey.of(

--- a/sdk-lambda/src/test/kotlin/dev/restate/sdk/lambda/testservices/KotlinCounterService.kt
+++ b/sdk-lambda/src/test/kotlin/dev/restate/sdk/lambda/testservices/KotlinCounterService.kt
@@ -8,12 +8,12 @@
 // https://github.com/restatedev/sdk-java/blob/main/LICENSE
 package dev.restate.sdk.lambda.testservices
 
-import dev.restate.sdk.kotlin.RestateCoroutineService
+import dev.restate.sdk.kotlin.RestateKtService
 import kotlinx.coroutines.Dispatchers
 
 class KotlinCounterService :
     KotlinCounterGrpcKt.KotlinCounterCoroutineImplBase(coroutineContext = Dispatchers.Unconfined),
-    RestateCoroutineService {
+    RestateKtService {
 
   override suspend fun get(request: CounterRequest): GetResponse {
     val count = (restateContext().get(JavaCounterService.COUNTER) ?: 0) + 1

--- a/sdk-testing/src/main/java/dev/restate/sdk/testing/RestateRunnerBuilder.java
+++ b/sdk-testing/src/main/java/dev/restate/sdk/testing/RestateRunnerBuilder.java
@@ -8,8 +8,8 @@
 // https://github.com/restatedev/sdk-java/blob/main/LICENSE
 package dev.restate.sdk.testing;
 
-import dev.restate.sdk.common.BindableBlockingService;
-import dev.restate.sdk.common.BindableNonBlockingService;
+import dev.restate.sdk.common.BlockingService;
+import dev.restate.sdk.common.NonBlockingService;
 import dev.restate.sdk.http.vertx.RestateHttpEndpointBuilder;
 import io.grpc.ServerInterceptor;
 import java.util.HashMap;
@@ -49,31 +49,31 @@ public class RestateRunnerBuilder {
   }
 
   /**
-   * Register a service. See {@link RestateHttpEndpointBuilder#withService(BindableBlockingService,
+   * Register a service. See {@link RestateHttpEndpointBuilder#withService(BlockingService,
    * ServerInterceptor...)}.
    */
   public RestateRunnerBuilder withService(
-      BindableBlockingService service, ServerInterceptor... interceptors) {
+      BlockingService service, ServerInterceptor... interceptors) {
     this.endpointBuilder.withService(service, interceptors);
     return this;
   }
 
   /**
-   * Register a service. See {@link RestateHttpEndpointBuilder#withService(BindableBlockingService,
+   * Register a service. See {@link RestateHttpEndpointBuilder#withService(BlockingService,
    * Executor, ServerInterceptor...)}.
    */
   public RestateRunnerBuilder withService(
-      BindableBlockingService service, Executor executor, ServerInterceptor... interceptors) {
+      BlockingService service, Executor executor, ServerInterceptor... interceptors) {
     this.endpointBuilder.withService(service, executor, interceptors);
     return this;
   }
 
   /**
-   * Register a service. See {@link
-   * RestateHttpEndpointBuilder#withService(BindableNonBlockingService, ServerInterceptor...)}.
+   * Register a service. See {@link RestateHttpEndpointBuilder#withService(NonBlockingService,
+   * ServerInterceptor...)}.
    */
   public RestateRunnerBuilder withService(
-      BindableNonBlockingService service, ServerInterceptor... interceptors) {
+      NonBlockingService service, ServerInterceptor... interceptors) {
     this.endpointBuilder.withService(service, interceptors);
     return this;
   }

--- a/sdk-testing/src/test/java/dev/restate/sdk/testing/Counter.java
+++ b/sdk-testing/src/test/java/dev/restate/sdk/testing/Counter.java
@@ -9,8 +9,8 @@
 package dev.restate.sdk.testing;
 
 import com.google.protobuf.Empty;
-import dev.restate.sdk.RestateBlockingService;
 import dev.restate.sdk.RestateContext;
+import dev.restate.sdk.RestateService;
 import dev.restate.sdk.common.CoreSerdes;
 import dev.restate.sdk.common.StateKey;
 import dev.restate.sdk.examples.generated.*;
@@ -18,7 +18,7 @@ import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class Counter extends CounterGrpc.CounterImplBase implements RestateBlockingService {
+public class Counter extends CounterGrpc.CounterImplBase implements RestateService {
 
   private static final Logger LOG = LogManager.getLogger(Counter.class);
 


### PR DESCRIPTION
Introduce Service parent marker interface.
Rename BindableBlockingService to BlockingService
Rename BindableNonBlockingService to NonBlockingService Rename RestateBlockingService to RestateService
Rename RestateCoroutinesService to RestateKtService
Javadoc'it all

Fix #169