### PR TITLE
Set default Restate container to docker.io/restatedev/restate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,6 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.GH_PACKAGE_READ_ACCESS_USER }}
-          password: ${{ secrets.GH_PACKAGE_READ_ACCESS_TOKEN }}
-
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
 

--- a/sdk-testing/src/main/java/dev/restate/sdk/testing/RestateRunnerBuilder.java
+++ b/sdk-testing/src/main/java/dev/restate/sdk/testing/RestateRunnerBuilder.java
@@ -19,10 +19,9 @@ import java.util.concurrent.Executor;
 /** Builder for {@link RestateRunner}. See {@link RestateRunner} for more details. */
 public class RestateRunnerBuilder {
 
-  private static final String DEFAULT_RUNTIME_CONTAINER = "ghcr.io/restatedev/restate-dist";
-
+  private static final String DEFAULT_RESTATE_CONTAINER = "docker.io/restatedev/restate";
   private final RestateHttpEndpointBuilder endpointBuilder;
-  private String runtimeContainerImage = DEFAULT_RUNTIME_CONTAINER;
+  private String restateContainerImage = DEFAULT_RESTATE_CONTAINER;
   private final Map<String, String> additionalEnv = new HashMap<>();
   private String configFile;
 
@@ -31,8 +30,8 @@ public class RestateRunnerBuilder {
   }
 
   /** Override the container image to use for the Restate runtime. */
-  public RestateRunnerBuilder withRuntimeContainerImage(String runtimeContainerImage) {
-    this.runtimeContainerImage = runtimeContainerImage;
+  public RestateRunnerBuilder withRestateContainerImage(String restateContainerImage) {
+    this.restateContainerImage = restateContainerImage;
     return this;
   }
 
@@ -81,7 +80,7 @@ public class RestateRunnerBuilder {
   public ManualRestateRunner buildManualRunner() {
     return new ManualRestateRunner(
         this.endpointBuilder.build(),
-        this.runtimeContainerImage,
+        this.restateContainerImage,
         this.additionalEnv,
         this.configFile);
   }

--- a/sdk-testing/src/test/java/dev/restate/sdk/testing/CounterTest.java
+++ b/sdk-testing/src/test/java/dev/restate/sdk/testing/CounterTest.java
@@ -21,7 +21,11 @@ class CounterTest {
 
   @RegisterExtension
   private static final RestateRunner restateRunner =
-      RestateRunnerBuilder.create().withService(new Counter()).buildRunner();
+      RestateRunnerBuilder.create()
+          .withRestateContainerImage(
+              "ghcr.io/restatedev/restate:main") // test against the latest main Restate image
+          .withService(new Counter())
+          .buildRunner();
 
   @Test
   void testGreet(@RestateGrpcChannel ManagedChannel channel) {


### PR DESCRIPTION
This commit sets the default Restate container to docker.io/restatedev/restate. Moreover, it configures the test to use ghcr.io/restatedev/restate:main to run against the latest main. This should help us detect breaking changes quickly.

This fixes #171.