### PR TITLE
Introduce deterministic random

### DIFF
--- a/sdk-api-kotlin/src/main/kotlin/dev/restate/sdk/kotlin/RestateContextImpl.kt
+++ b/sdk-api-kotlin/src/main/kotlin/dev/restate/sdk/kotlin/RestateContextImpl.kt
@@ -9,6 +9,7 @@
 package dev.restate.sdk.kotlin
 
 import com.google.protobuf.ByteString
+import dev.restate.sdk.common.InvocationId
 import dev.restate.sdk.common.Serde
 import dev.restate.sdk.common.StateKey
 import dev.restate.sdk.common.TerminalException
@@ -19,6 +20,7 @@ import dev.restate.sdk.common.syscalls.Syscalls
 import io.grpc.MethodDescriptor
 import java.lang.Error
 import kotlin.coroutines.resume
+import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.toJavaDuration
 import kotlinx.coroutines.*
@@ -183,5 +185,9 @@ internal class RestateContextImpl internal constructor(private val syscalls: Sys
 
   override fun awakeableHandle(id: String): AwakeableHandle {
     return AwakeableHandleImpl(syscalls, id)
+  }
+
+  override fun random(): Random {
+    return Random(InvocationId.current().toRandomSeed())
   }
 }

--- a/sdk-api-kotlin/src/main/kotlin/dev/restate/sdk/kotlin/RestateContextImpl.kt
+++ b/sdk-api-kotlin/src/main/kotlin/dev/restate/sdk/kotlin/RestateContextImpl.kt
@@ -20,7 +20,6 @@ import dev.restate.sdk.common.syscalls.Syscalls
 import io.grpc.MethodDescriptor
 import java.lang.Error
 import kotlin.coroutines.resume
-import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.toJavaDuration
 import kotlinx.coroutines.*
@@ -187,7 +186,7 @@ internal class RestateContextImpl internal constructor(private val syscalls: Sys
     return AwakeableHandleImpl(syscalls, id)
   }
 
-  override fun random(): Random {
-    return Random(InvocationId.current().toRandomSeed())
+  override fun random(): RestateRandom {
+    return RestateRandom(InvocationId.current().toRandomSeed(), syscalls)
   }
 }

--- a/sdk-api-kotlin/src/main/kotlin/dev/restate/sdk/kotlin/api.kt
+++ b/sdk-api-kotlin/src/main/kotlin/dev/restate/sdk/kotlin/api.kt
@@ -15,6 +15,7 @@ import dev.restate.sdk.common.StateKey
 import dev.restate.sdk.common.syscalls.Syscalls
 import io.grpc.MethodDescriptor
 import java.util.*
+import kotlin.random.Random
 import kotlin.time.Duration
 
 /**
@@ -198,6 +199,20 @@ sealed interface RestateContext {
    * @see Awakeable
    */
   fun awakeableHandle(id: String): AwakeableHandle
+
+  /**
+   * Create a [Random] instance inherently predictable, seeded on the
+   * [dev.restate.sdk.common.InvocationId], which is not secret.
+   *
+   * This instance is useful to generate identifiers, idempotency keys, and for uniform sampling
+   * from a set of options. If a cryptographically secure value is needed, please generate that
+   * externally using [sideEffect].
+   *
+   * You MUST NOT use this [Random] instance inside a [sideEffect].
+   *
+   * @return the [Random] instance.
+   */
+  fun random(): Random
 }
 
 /**

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/KotlinCoroutinesTests.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/KotlinCoroutinesTests.kt
@@ -20,7 +20,7 @@ class KotlinCoroutinesTests : TestRunner() {
     return Stream.of(MockSingleThread.INSTANCE, MockMultiThreaded.INSTANCE)
   }
 
-  override fun definitions(): Stream<TestDefinitions.TestSuite> {
+  public override fun definitions(): Stream<TestDefinitions.TestSuite> {
     return Stream.of(
         AwakeableIdTest(),
         DeferredTest(),

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/KotlinCoroutinesTests.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/KotlinCoroutinesTests.kt
@@ -31,6 +31,7 @@ class KotlinCoroutinesTests : TestRunner() {
         SideEffectTest(),
         SleepTest(),
         StateMachineFailuresTest(),
-        UserFailuresTest())
+        UserFailuresTest(),
+        RandomTest())
   }
 }

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/RandomTest.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/RandomTest.kt
@@ -1,0 +1,50 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate Java SDK,
+// which is released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/sdk-java/blob/main/LICENSE
+package dev.restate.sdk.kotlin
+
+import dev.restate.sdk.core.RandomTestSuite
+import dev.restate.sdk.core.testservices.GreeterGrpcKt
+import dev.restate.sdk.core.testservices.GreetingRequest
+import dev.restate.sdk.core.testservices.GreetingResponse
+import dev.restate.sdk.core.testservices.greetingResponse
+import io.grpc.BindableService
+import kotlin.random.Random
+import kotlinx.coroutines.Dispatchers
+
+class RandomTest : RandomTestSuite() {
+  private class RandomShouldBeDeterministic :
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
+
+    override suspend fun greet(request: GreetingRequest): GreetingResponse {
+      val number = restateContext().random().nextInt()
+      return greetingResponse { message = number.toString() }
+    }
+  }
+
+  override fun randomShouldBeDeterministic(): BindableService {
+    return RandomShouldBeDeterministic()
+  }
+
+  private class RandomInsideSideEffect :
+      GreeterGrpcKt.GreeterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
+    override suspend fun greet(request: GreetingRequest): GreetingResponse {
+      val ctx = restateContext()
+      ctx.sideEffect { ctx.random().nextInt() }
+      throw IllegalStateException("This should not unreachable")
+    }
+  }
+
+  override fun randomInsideSideEffect(): BindableService {
+    return RandomInsideSideEffect()
+  }
+
+  override fun getExpectedInt(seed: Long): Int {
+    return Random(seed).nextInt()
+  }
+}

--- a/sdk-api/src/main/java/dev/restate/sdk/RestateContext.java
+++ b/sdk-api/src/main/java/dev/restate/sdk/RestateContext.java
@@ -16,7 +16,6 @@ import io.grpc.Channel;
 import io.grpc.MethodDescriptor;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.Random;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -209,19 +208,9 @@ public interface RestateContext {
   AwakeableHandle awakeableHandle(String id);
 
   /**
-   * Create a {@link Random} instance inherently predictable, seeded on the {@link InvocationId},
-   * which is not secret.
-   *
-   * <p>This instance is useful to generate identifiers, idempotency keys, and for uniform sampling
-   * from a set of options. If a cryptographically secure value is needed, please generate that
-   * externally using {@link #sideEffect(Serde, ThrowingSupplier)}.
-   *
-   * <p>You MUST NOT use this {@link Random} instance inside a {@link #sideEffect(Serde,
-   * ThrowingSupplier)}.
-   *
-   * @return the {@link Random} instance.
+   * @see RestateRandom
    */
-  Random random();
+  RestateRandom random();
 
   /**
    * Build a RestateContext from the underlying {@link Syscalls} object.

--- a/sdk-api/src/main/java/dev/restate/sdk/RestateContext.java
+++ b/sdk-api/src/main/java/dev/restate/sdk/RestateContext.java
@@ -16,6 +16,7 @@ import io.grpc.Channel;
 import io.grpc.MethodDescriptor;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.Random;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -206,6 +207,21 @@ public interface RestateContext {
    * @see Awakeable
    */
   AwakeableHandle awakeableHandle(String id);
+
+  /**
+   * Create a {@link Random} instance inherently predictable, seeded on the {@link InvocationId},
+   * which is not secret.
+   *
+   * <p>This instance is useful to generate identifiers, idempotency keys, and for uniform sampling
+   * from a set of options. If a cryptographically secure value is needed, please generate that
+   * externally using {@link #sideEffect(Serde, ThrowingSupplier)}.
+   *
+   * <p>You MUST NOT use this {@link Random} instance inside a {@link #sideEffect(Serde,
+   * ThrowingSupplier)}.
+   *
+   * @return the {@link Random} instance.
+   */
+  Random random();
 
   /**
    * Build a RestateContext from the underlying {@link Syscalls} object.

--- a/sdk-api/src/main/java/dev/restate/sdk/RestateContextImpl.java
+++ b/sdk-api/src/main/java/dev/restate/sdk/RestateContextImpl.java
@@ -186,6 +186,6 @@ class RestateContextImpl implements RestateContext {
 
   @Override
   public RestateRandom random() {
-    return new RestateRandom(InvocationId.current().toRandomSeed());
+    return new RestateRandom(InvocationId.current().toRandomSeed(), this.syscalls);
   }
 }

--- a/sdk-api/src/main/java/dev/restate/sdk/RestateContextImpl.java
+++ b/sdk-api/src/main/java/dev/restate/sdk/RestateContextImpl.java
@@ -19,7 +19,6 @@ import io.grpc.MethodDescriptor;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -186,7 +185,7 @@ class RestateContextImpl implements RestateContext {
   }
 
   @Override
-  public Random random() {
-    return new Random(InvocationId.current().toRandomSeed());
+  public RestateRandom random() {
+    return new RestateRandom(InvocationId.current().toRandomSeed());
   }
 }

--- a/sdk-api/src/main/java/dev/restate/sdk/RestateContextImpl.java
+++ b/sdk-api/src/main/java/dev/restate/sdk/RestateContextImpl.java
@@ -9,10 +9,7 @@
 package dev.restate.sdk;
 
 import com.google.protobuf.ByteString;
-import dev.restate.sdk.common.AbortedExecutionException;
-import dev.restate.sdk.common.Serde;
-import dev.restate.sdk.common.StateKey;
-import dev.restate.sdk.common.TerminalException;
+import dev.restate.sdk.common.*;
 import dev.restate.sdk.common.function.ThrowingSupplier;
 import dev.restate.sdk.common.syscalls.DeferredResult;
 import dev.restate.sdk.common.syscalls.EnterSideEffectSyscallCallback;
@@ -22,6 +19,7 @@ import io.grpc.MethodDescriptor;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -185,5 +183,10 @@ class RestateContextImpl implements RestateContext {
         Util.<Void>blockOnSyscall(cb -> syscalls.rejectAwakeable(id, reason, cb));
       }
     };
+  }
+
+  @Override
+  public Random random() {
+    return new Random(InvocationId.current().toRandomSeed());
   }
 }

--- a/sdk-api/src/main/java/dev/restate/sdk/RestateRandom.java
+++ b/sdk-api/src/main/java/dev/restate/sdk/RestateRandom.java
@@ -1,0 +1,47 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate Java SDK,
+// which is released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/sdk-java/blob/main/LICENSE
+package dev.restate.sdk;
+
+import dev.restate.sdk.common.InvocationId;
+import dev.restate.sdk.common.Serde;
+import dev.restate.sdk.common.function.ThrowingSupplier;
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * Subclass of {@link Random} inherently predictable, seeded on the {@link InvocationId}, which is
+ * not secret.
+ *
+ * <p>This instance is useful to generate identifiers, idempotency keys, and for uniform sampling
+ * from a set of options. If a cryptographically secure value is needed, please generate that
+ * externally using {@link RestateContext#sideEffect(Serde, ThrowingSupplier)}.
+ *
+ * <p>You MUST NOT use this object inside a {@link RestateContext#sideEffect(Serde,
+ * ThrowingSupplier)}.
+ */
+public class RestateRandom extends Random {
+  RestateRandom(long randomSeed) {
+    super(randomSeed);
+  }
+
+  /**
+   * @throws UnsupportedOperationException You cannot set the seed on RestateRandom
+   */
+  @Override
+  public synchronized void setSeed(long seed) {
+    throw new UnsupportedOperationException("You cannot set the seed on RestateRandom");
+  }
+
+  /**
+   * @return a UUID generated using this RNG.
+   */
+  public UUID nextUUID() {
+    return new UUID(this.nextLong(), this.nextLong());
+  }
+}

--- a/sdk-api/src/test/java/dev/restate/sdk/JavaBlockingTests.java
+++ b/sdk-api/src/test/java/dev/restate/sdk/JavaBlockingTests.java
@@ -23,7 +23,7 @@ public class JavaBlockingTests extends TestRunner {
   }
 
   @Override
-  protected Stream<TestSuite> definitions() {
+  public Stream<TestSuite> definitions() {
     return Stream.of(
         new AwakeableIdTest(),
         new DeferredTest(),
@@ -36,6 +36,7 @@ public class JavaBlockingTests extends TestRunner {
         new StateMachineFailuresTest(),
         new UserFailuresTest(),
         new GrpcChannelAdapterTest(),
-        new RestateCodegenTest());
+        new RestateCodegenTest(),
+        new RandomTest());
   }
 }

--- a/sdk-api/src/test/java/dev/restate/sdk/RandomTest.java
+++ b/sdk-api/src/test/java/dev/restate/sdk/RandomTest.java
@@ -1,0 +1,48 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate Java SDK,
+// which is released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/sdk-java/blob/main/LICENSE
+package dev.restate.sdk;
+
+import dev.restate.sdk.common.TerminalException;
+import dev.restate.sdk.core.RandomTestSuite;
+import dev.restate.sdk.core.testservices.GreeterRestate;
+import dev.restate.sdk.core.testservices.GreetingRequest;
+import dev.restate.sdk.core.testservices.GreetingResponse;
+import io.grpc.BindableService;
+
+public class RandomTest extends RandomTestSuite {
+
+  private static class RandomShouldBeDeterministic extends GreeterRestate.GreeterRestateImplBase {
+    @Override
+    public GreetingResponse greet(RestateContext context, GreetingRequest request)
+        throws TerminalException {
+      return GreetingResponse.newBuilder()
+          .setMessage(Integer.toString(context.random().nextInt()))
+          .build();
+    }
+  }
+
+  @Override
+  protected BindableService randomShouldBeDeterministic() {
+    return new RandomShouldBeDeterministic();
+  }
+
+  private static class RandomInsideSideEffect extends GreeterRestate.GreeterRestateImplBase {
+    @Override
+    public GreetingResponse greet(RestateContext context, GreetingRequest request)
+        throws TerminalException {
+      context.sideEffect(() -> context.random().nextInt());
+      throw new IllegalStateException("This should not unreachable");
+    }
+  }
+
+  @Override
+  protected BindableService randomInsideSideEffect() {
+    return new RandomInsideSideEffect();
+  }
+}

--- a/sdk-api/src/test/java/dev/restate/sdk/RandomTest.java
+++ b/sdk-api/src/test/java/dev/restate/sdk/RandomTest.java
@@ -14,6 +14,7 @@ import dev.restate.sdk.core.testservices.GreeterRestate;
 import dev.restate.sdk.core.testservices.GreetingRequest;
 import dev.restate.sdk.core.testservices.GreetingResponse;
 import io.grpc.BindableService;
+import java.util.Random;
 
 public class RandomTest extends RandomTestSuite {
 
@@ -44,5 +45,10 @@ public class RandomTest extends RandomTestSuite {
   @Override
   protected BindableService randomInsideSideEffect() {
     return new RandomInsideSideEffect();
+  }
+
+  @Override
+  protected int getExpectedInt(long seed) {
+    return new Random(seed).nextInt();
   }
 }

--- a/sdk-common/src/main/java/dev/restate/sdk/common/InvocationId.java
+++ b/sdk-common/src/main/java/dev/restate/sdk/common/InvocationId.java
@@ -28,6 +28,11 @@ public interface InvocationId {
     return INVOCATION_ID_KEY.get();
   }
 
+  /**
+   * @return a seed to be used with {@link java.util.Random}.
+   */
+  long toRandomSeed();
+
   @Override
   String toString();
 }

--- a/sdk-common/src/main/java/dev/restate/sdk/common/syscalls/Syscalls.java
+++ b/sdk-common/src/main/java/dev/restate/sdk/common/syscalls/Syscalls.java
@@ -41,6 +41,11 @@ public interface Syscalls {
             + Thread.currentThread().getName());
   }
 
+  /**
+   * @return true if it's inside a side effect block.
+   */
+  boolean isInsideSideEffect();
+
   // ----- IO
   // Note: These are not supposed to be exposed to RestateContext, but they should be used through
   // gRPC APIs.

--- a/sdk-core/src/main/java/dev/restate/sdk/core/ExecutorSwitchingWrappers.java
+++ b/sdk-core/src/main/java/dev/restate/sdk/core/ExecutorSwitchingWrappers.java
@@ -194,6 +194,12 @@ class ExecutorSwitchingWrappers {
     }
 
     @Override
+    public boolean isInsideSideEffect() {
+      // We can read this from another thread
+      return syscalls.isInsideSideEffect();
+    }
+
+    @Override
     public void close() {
       syscallsExecutor.execute(syscalls::close);
     }

--- a/sdk-core/src/main/java/dev/restate/sdk/core/InvocationIdImpl.java
+++ b/sdk-core/src/main/java/dev/restate/sdk/core/InvocationIdImpl.java
@@ -33,7 +33,25 @@ final class InvocationIdImpl implements InvocationId {
   }
 
   @Override
+  public long toRandomSeed() {
+    return stringToSeed(id);
+  }
+
+  @Override
   public String toString() {
     return id;
+  }
+
+  // Thanks https://stackoverflow.com/questions/12458383/java-random-numbers-using-a-seed
+  static long stringToSeed(String s) {
+    if (s == null) {
+      return 0;
+    }
+    long hash = 0;
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      hash = 31L * hash + c;
+    }
+    return hash;
   }
 }

--- a/sdk-core/src/main/java/dev/restate/sdk/core/InvocationStateMachine.java
+++ b/sdk-core/src/main/java/dev/restate/sdk/core/InvocationStateMachine.java
@@ -41,7 +41,7 @@ class InvocationStateMachine implements InvocationFlow.InvocationProcessor {
   private volatile InvocationState invocationState = InvocationState.WAITING_START;
 
   // Used for the side effect guard
-  private boolean insideSideEffect = false;
+  private volatile boolean insideSideEffect = false;
 
   // Obtained after WAITING_START
   private ByteString id;
@@ -95,6 +95,10 @@ class InvocationStateMachine implements InvocationFlow.InvocationProcessor {
 
   public InvocationState getInvocationState() {
     return this.invocationState;
+  }
+
+  public boolean isInsideSideEffect() {
+    return this.insideSideEffect;
   }
 
   public String getFullyQualifiedMethodName() {

--- a/sdk-core/src/main/java/dev/restate/sdk/core/SyscallsImpl.java
+++ b/sdk-core/src/main/java/dev/restate/sdk/core/SyscallsImpl.java
@@ -328,6 +328,11 @@ public final class SyscallsImpl implements SyscallsInternal {
   }
 
   @Override
+  public boolean isInsideSideEffect() {
+    return this.stateMachine.isInsideSideEffect();
+  }
+
+  @Override
   public void close() {
     this.stateMachine.end();
   }

--- a/sdk-core/src/test/java/dev/restate/sdk/core/RandomTestSuite.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/RandomTestSuite.java
@@ -27,6 +27,8 @@ public abstract class RandomTestSuite implements TestSuite {
 
   protected abstract BindableService randomInsideSideEffect();
 
+  protected abstract int getExpectedInt(long seed);
+
   @Override
   public Stream<TestDefinition> definitions() {
     String debugId = "my-id";
@@ -38,7 +40,10 @@ public abstract class RandomTestSuite implements TestSuite {
                 Protocol.StartMessage.newBuilder().setDebugId(debugId).setKnownEntries(1),
                 inputMessage(GreetingRequest.getDefaultInstance()))
             .expectingOutput(
-                outputMessage(greetingResponse(Integer.toString(expectedRandomNumber))),
+                outputMessage(
+                    greetingResponse(
+                        Integer.toString(
+                            getExpectedInt(new InvocationIdImpl(debugId).toRandomSeed())))),
                 END_MESSAGE),
         testInvocation(this::randomInsideSideEffect, GreeterGrpc.getGreetMethod())
             .withInput(

--- a/sdk-core/src/test/java/dev/restate/sdk/core/RandomTestSuite.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/RandomTestSuite.java
@@ -1,0 +1,52 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate Java SDK,
+// which is released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/sdk-java/blob/main/LICENSE
+package dev.restate.sdk.core;
+
+import static dev.restate.sdk.core.AssertUtils.*;
+import static dev.restate.sdk.core.ProtoUtils.*;
+import static dev.restate.sdk.core.TestDefinitions.testInvocation;
+
+import dev.restate.generated.service.protocol.Protocol;
+import dev.restate.sdk.core.TestDefinitions.TestDefinition;
+import dev.restate.sdk.core.TestDefinitions.TestSuite;
+import dev.restate.sdk.core.testservices.GreeterGrpc;
+import dev.restate.sdk.core.testservices.GreetingRequest;
+import io.grpc.BindableService;
+import java.util.Random;
+import java.util.stream.Stream;
+
+public abstract class RandomTestSuite implements TestSuite {
+
+  protected abstract BindableService randomShouldBeDeterministic();
+
+  protected abstract BindableService randomInsideSideEffect();
+
+  @Override
+  public Stream<TestDefinition> definitions() {
+    String debugId = "my-id";
+
+    int expectedRandomNumber = new Random(new InvocationIdImpl(debugId).toRandomSeed()).nextInt();
+    return Stream.of(
+        testInvocation(this::randomShouldBeDeterministic, GreeterGrpc.getGreetMethod())
+            .withInput(
+                Protocol.StartMessage.newBuilder().setDebugId(debugId).setKnownEntries(1),
+                inputMessage(GreetingRequest.getDefaultInstance()))
+            .expectingOutput(
+                outputMessage(greetingResponse(Integer.toString(expectedRandomNumber))),
+                END_MESSAGE),
+        testInvocation(this::randomInsideSideEffect, GreeterGrpc.getGreetMethod())
+            .withInput(
+                Protocol.StartMessage.newBuilder().setDebugId(debugId).setKnownEntries(1),
+                inputMessage(GreetingRequest.getDefaultInstance()))
+            .assertingOutput(
+                containsOnlyExactErrorMessage(
+                    new IllegalStateException(
+                        "You can't use RestateRandom inside a side effect!"))));
+  }
+}

--- a/sdk-http-vertx/src/test/kotlin/dev/restate/sdk/http/vertx/HttpVertxTests.kt
+++ b/sdk-http-vertx/src/test/kotlin/dev/restate/sdk/http/vertx/HttpVertxTests.kt
@@ -10,12 +10,14 @@ package dev.restate.sdk.http.vertx
 
 import com.google.protobuf.ByteString
 import dev.restate.generated.sdk.java.Java.SideEffectEntryMessage
+import dev.restate.sdk.JavaBlockingTests
 import dev.restate.sdk.RestateService
 import dev.restate.sdk.core.ProtoUtils.*
 import dev.restate.sdk.core.TestDefinitions.*
 import dev.restate.sdk.core.testservices.GreeterGrpc
 import dev.restate.sdk.core.testservices.GreetingRequest
 import dev.restate.sdk.core.testservices.GreetingResponse
+import dev.restate.sdk.kotlin.KotlinCoroutinesTests
 import dev.restate.sdk.kotlin.RestateKtService
 import io.grpc.stub.StreamObserver
 import io.vertx.core.Vertx
@@ -101,28 +103,11 @@ class HttpVertxTests : dev.restate.sdk.core.TestRunner() {
   }
 
   override fun definitions(): Stream<TestSuite> {
-    return Stream.of(
-        dev.restate.sdk.AwakeableIdTest(),
-        dev.restate.sdk.DeferredTest(),
-        dev.restate.sdk.EagerStateTest(),
-        dev.restate.sdk.StateTest(),
-        dev.restate.sdk.InvocationIdTest(),
-        dev.restate.sdk.OnlyInputAndOutputTest(),
-        dev.restate.sdk.SideEffectTest(),
-        dev.restate.sdk.SleepTest(),
-        dev.restate.sdk.StateMachineFailuresTest(),
-        dev.restate.sdk.UserFailuresTest(),
-        dev.restate.sdk.GrpcChannelAdapterTest(),
-        dev.restate.sdk.kotlin.AwakeableIdTest(),
-        dev.restate.sdk.kotlin.DeferredTest(),
-        dev.restate.sdk.kotlin.EagerStateTest(),
-        dev.restate.sdk.kotlin.StateTest(),
-        dev.restate.sdk.kotlin.InvocationIdTest(),
-        dev.restate.sdk.kotlin.OnlyInputAndOutputTest(),
-        dev.restate.sdk.kotlin.SideEffectTest(),
-        dev.restate.sdk.kotlin.SleepTest(),
-        dev.restate.sdk.kotlin.StateMachineFailuresTest(),
-        dev.restate.sdk.kotlin.UserFailuresTest(),
-        VertxExecutorsTest())
+    return Stream.concat(
+        Stream.concat(
+            JavaBlockingTests().definitions(),
+            KotlinCoroutinesTests().definitions(),
+        ),
+        Stream.of(VertxExecutorsTest()))
   }
 }


### PR DESCRIPTION
Fix #155.

Please note that because the JDK `UUID` class doesn't have a way to specify a seed to its internal RNG, we can't use this `Random` instance to generate uuids. Perhaps we can re-iterate on this later by adding a method ourselves?