### PR TITLE
Update SDK to use restatedev/service-protocol#58 

### DIFF
--- a/sdk-common/src/main/java/dev/restate/sdk/common/CoreSerdes.java
+++ b/sdk-common/src/main/java/dev/restate/sdk/common/CoreSerdes.java
@@ -105,16 +105,16 @@ public abstract class CoreSerdes {
           boxedN -> {
             int n = boxedN;
             byte[] encodedValue = new byte[Integer.SIZE / Byte.SIZE];
-            encodedValue[3] = (byte) (n >> Byte.SIZE * 3);
-            encodedValue[2] = (byte) (n >> Byte.SIZE * 2);
+            encodedValue[3] = (byte) (n >> (Byte.SIZE * 3));
+            encodedValue[2] = (byte) (n >> (Byte.SIZE * 2));
             encodedValue[1] = (byte) (n >> Byte.SIZE);
             encodedValue[0] = (byte) n;
             return encodedValue;
           },
           encodedValue -> {
             int n = 0;
-            n |= (encodedValue[3] & 0xFF) << Byte.SIZE * 3;
-            n |= (encodedValue[2] & 0xFF) << Byte.SIZE * 2;
+            n |= (encodedValue[3] & 0xFF) << (Byte.SIZE * 3);
+            n |= (encodedValue[2] & 0xFF) << (Byte.SIZE * 2);
             n |= (encodedValue[1] & 0xFF) << Byte.SIZE;
             n |= encodedValue[0] & 0xFF;
             return n;
@@ -125,24 +125,24 @@ public abstract class CoreSerdes {
           boxedN -> {
             long n = boxedN;
             byte[] encodedValue = new byte[Long.SIZE / Byte.SIZE];
-            encodedValue[7] = (byte) (n >> Byte.SIZE * 7);
-            encodedValue[6] = (byte) (n >> Byte.SIZE * 6);
-            encodedValue[5] = (byte) (n >> Byte.SIZE * 5);
-            encodedValue[4] = (byte) (n >> Byte.SIZE * 4);
-            encodedValue[3] = (byte) (n >> Byte.SIZE * 3);
-            encodedValue[2] = (byte) (n >> Byte.SIZE * 2);
+            encodedValue[7] = (byte) (n >> (Byte.SIZE * 7));
+            encodedValue[6] = (byte) (n >> (Byte.SIZE * 6));
+            encodedValue[5] = (byte) (n >> (Byte.SIZE * 5));
+            encodedValue[4] = (byte) (n >> (Byte.SIZE * 4));
+            encodedValue[3] = (byte) (n >> (Byte.SIZE * 3));
+            encodedValue[2] = (byte) (n >> (Byte.SIZE * 2));
             encodedValue[1] = (byte) (n >> Byte.SIZE);
             encodedValue[0] = (byte) n;
             return encodedValue;
           },
           encodedValue -> {
             long n = 0;
-            n |= ((long) (encodedValue[7] & 0xFF) << Byte.SIZE * 7);
-            n |= ((long) (encodedValue[6] & 0xFF) << Byte.SIZE * 6);
-            n |= ((long) (encodedValue[5] & 0xFF) << Byte.SIZE * 5);
-            n |= ((long) (encodedValue[4] & 0xFF) << Byte.SIZE * 4);
-            n |= ((long) (encodedValue[3] & 0xFF) << Byte.SIZE * 3);
-            n |= ((encodedValue[2] & 0xFF) << Byte.SIZE * 2);
+            n |= ((long) (encodedValue[7] & 0xFF) << (Byte.SIZE * 7));
+            n |= ((long) (encodedValue[6] & 0xFF) << (Byte.SIZE * 6));
+            n |= ((long) (encodedValue[5] & 0xFF) << (Byte.SIZE * 5));
+            n |= ((long) (encodedValue[4] & 0xFF) << (Byte.SIZE * 4));
+            n |= ((long) (encodedValue[3] & 0xFF) << (Byte.SIZE * 3));
+            n |= ((encodedValue[2] & 0xFF) << (Byte.SIZE * 2));
             n |= ((encodedValue[1] & 0xFF) << Byte.SIZE);
             n |= (encodedValue[0] & 0xFF);
             return n;

--- a/sdk-core/src/main/java/dev/restate/sdk/core/MessageHeader.java
+++ b/sdk-core/src/main/java/dev/restate/sdk/core/MessageHeader.java
@@ -63,7 +63,13 @@ public class MessageHeader {
     } else if (msg instanceof Protocol.EntryAckMessage) {
       return new MessageHeader(MessageType.EntryAckMessage, 0, msg.getSerializedSize());
     } else if (msg instanceof Protocol.PollInputStreamEntryMessage) {
-      return new MessageHeader(MessageType.PollInputStreamEntryMessage, 0, msg.getSerializedSize());
+      return new MessageHeader(
+          MessageType.PollInputStreamEntryMessage,
+          ((Protocol.PollInputStreamEntryMessage) msg).getResultCase()
+                  != Protocol.PollInputStreamEntryMessage.ResultCase.RESULT_NOT_SET
+              ? DONE_FLAG
+              : 0,
+          msg.getSerializedSize());
     } else if (msg instanceof Protocol.OutputStreamEntryMessage) {
       return new MessageHeader(MessageType.OutputStreamEntryMessage, 0, msg.getSerializedSize());
     } else if (msg instanceof Protocol.GetStateEntryMessage) {
@@ -81,7 +87,10 @@ public class MessageHeader {
     } else if (msg instanceof Protocol.SleepEntryMessage) {
       return new MessageHeader(
           MessageType.SleepEntryMessage,
-          ((Protocol.SleepEntryMessage) msg).hasResult() ? DONE_FLAG : 0,
+          ((Protocol.SleepEntryMessage) msg).getResultCase()
+                  != Protocol.SleepEntryMessage.ResultCase.RESULT_NOT_SET
+              ? DONE_FLAG
+              : 0,
           msg.getSerializedSize());
     } else if (msg instanceof Protocol.InvokeEntryMessage) {
       return new MessageHeader(

--- a/sdk-core/src/main/java/dev/restate/sdk/core/RestateServerCall.java
+++ b/sdk-core/src/main/java/dev/restate/sdk/core/RestateServerCall.java
@@ -89,13 +89,12 @@ class RestateServerCall extends ServerCall<MessageLite, MessageLite> {
 
   @Override
   public void close(Status status, Metadata trailers) {
+    // Let's close the listener first
+    listener.close();
+
     if (status.isOk() || Util.containsSuspendedException(status.getCause())) {
-      listener.close();
       syscalls.close();
     } else {
-      // Let's cancel the listener first
-      listener.cancel();
-
       if (Util.isTerminalException(status.getCause())) {
         syscalls.writeOutput(
             (TerminalException) status.getCause(),

--- a/sdk-core/src/test/java/dev/restate/sdk/core/OnlyInputAndOutputTestSuite.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/OnlyInputAndOutputTestSuite.java
@@ -12,6 +12,7 @@ import static dev.restate.sdk.core.ProtoUtils.*;
 import static dev.restate.sdk.core.TestDefinitions.TestDefinition;
 import static dev.restate.sdk.core.TestDefinitions.testInvocation;
 
+import dev.restate.sdk.common.TerminalException;
 import dev.restate.sdk.core.TestDefinitions.TestSuite;
 import dev.restate.sdk.core.testservices.GreeterGrpc;
 import dev.restate.sdk.core.testservices.GreetingRequest;
@@ -30,7 +31,12 @@ public abstract class OnlyInputAndOutputTestSuite implements TestSuite {
             .withInput(
                 startMessage(1), inputMessage(GreetingRequest.newBuilder().setName("Francesco")))
             .expectingOutput(
-                outputMessage(
-                    GreetingResponse.newBuilder().setMessage("Hello Francesco").build())));
+                outputMessage(GreetingResponse.newBuilder().setMessage("Hello Francesco").build())),
+        testInvocation(this::noSyscallsGreeter, GreeterGrpc.getGreetMethod())
+            .withInput(
+                startMessage(1),
+                inputMessage(new TerminalException(TerminalException.Code.CANCELLED)))
+            .expectingOutput(
+                outputMessage(new TerminalException(TerminalException.Code.CANCELLED))));
   }
 }

--- a/sdk-core/src/test/java/dev/restate/sdk/core/ProtoUtils.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/ProtoUtils.java
@@ -98,6 +98,12 @@ public class ProtoUtils {
         .build();
   }
 
+  public static Protocol.PollInputStreamEntryMessage inputMessage(Throwable error) {
+    return Protocol.PollInputStreamEntryMessage.newBuilder()
+        .setFailure(Util.toProtocolFailure(error))
+        .build();
+  }
+
   public static Protocol.OutputStreamEntryMessage outputMessage(MessageLiteOrBuilder value) {
     return Protocol.OutputStreamEntryMessage.newBuilder()
         .setValue(build(value).toByteString())
@@ -119,6 +125,10 @@ public class ProtoUtils {
 
   public static Protocol.GetStateEntryMessage.Builder getStateMessage(String key) {
     return Protocol.GetStateEntryMessage.newBuilder().setKey(ByteString.copyFromUtf8(key));
+  }
+
+  public static Protocol.GetStateEntryMessage.Builder getStateMessage(String key, Throwable error) {
+    return getStateMessage(key).setFailure(Util.toProtocolFailure(error));
   }
 
   public static Protocol.GetStateEntryMessage getStateEmptyMessage(String key) {

--- a/sdk-lambda/src/test/java/dev/restate/sdk/lambda/LambdaHandlerTest.java
+++ b/sdk-lambda/src/test/java/dev/restate/sdk/lambda/LambdaHandlerTest.java
@@ -22,7 +22,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.MessageLite;
 import dev.restate.generated.service.discovery.Discovery;
 import dev.restate.generated.service.protocol.Protocol;
-import dev.restate.sdk.core.MessageHeader;
 import dev.restate.sdk.core.ProtoUtils;
 import dev.restate.sdk.lambda.testservices.CounterRequest;
 import dev.restate.sdk.lambda.testservices.JavaCounterGrpc;
@@ -125,23 +124,6 @@ class LambdaHandlerTest {
       msg.writeTo(outputStream);
     }
     return outputStream.toByteArray();
-  }
-
-  private static List<MessageLite> deserializeEntries(byte[] array) throws IOException {
-    List<MessageLite> msgs = new ArrayList<>();
-    ByteBuffer buffer = ByteBuffer.wrap(array);
-    while (buffer.hasRemaining()) {
-      MessageHeader header = MessageHeader.parse(buffer.getLong());
-
-      // Prepare the ByteBuffer and pass it to the Protobuf message parser
-      ByteBuffer messageBuffer = buffer.slice();
-      messageBuffer.limit(header.getLength());
-      msgs.add(header.getType().messageParser().parseFrom(messageBuffer));
-
-      // Move the buffer after this message
-      buffer.position(buffer.position() + header.getLength());
-    }
-    return msgs;
   }
 
   private Context mockContext() {

--- a/sdk-lambda/src/test/java/dev/restate/sdk/lambda/testservices/JavaCounterService.java
+++ b/sdk-lambda/src/test/java/dev/restate/sdk/lambda/testservices/JavaCounterService.java
@@ -26,7 +26,7 @@ public class JavaCounterService extends JavaCounterGrpc.JavaCounterImplBase
 
   @Override
   public void get(CounterRequest request, StreamObserver<GetResponse> responseObserver) {
-    var count = restateContext().get(COUNTER).orElse(0L) + 1;
+    restateContext().get(COUNTER);
 
     throw new IllegalStateException("We shouldn't reach this point");
   }

--- a/sdk-lambda/src/test/kotlin/dev/restate/sdk/lambda/testservices/KotlinCounterService.kt
+++ b/sdk-lambda/src/test/kotlin/dev/restate/sdk/lambda/testservices/KotlinCounterService.kt
@@ -16,7 +16,7 @@ class KotlinCounterService :
     RestateKtService {
 
   override suspend fun get(request: CounterRequest): GetResponse {
-    val count = (restateContext().get(JavaCounterService.COUNTER) ?: 0) + 1
+    (restateContext().get(JavaCounterService.COUNTER) ?: 0) + 1
 
     throw IllegalStateException("We shouldn't reach this point")
   }

--- a/sdk-testing/src/main/java/dev/restate/sdk/testing/BaseRestateRunner.java
+++ b/sdk-testing/src/main/java/dev/restate/sdk/testing/BaseRestateRunner.java
@@ -32,8 +32,8 @@ abstract class BaseRestateRunner implements ParameterResolver {
         || (parameterContext.isAnnotated(RestateGrpcChannel.class)
             && ManagedChannel.class.isAssignableFrom(parameterContext.getParameter().getType()))
         || (parameterContext.isAnnotated(RestateURL.class)
-                && String.class.isAssignableFrom(parameterContext.getParameter().getType())
-            || URL.class.isAssignableFrom(parameterContext.getParameter().getType()));
+            && (String.class.isAssignableFrom(parameterContext.getParameter().getType())
+                || URL.class.isAssignableFrom(parameterContext.getParameter().getType())));
   }
 
   @Override

--- a/sdk-testing/src/main/java/dev/restate/sdk/testing/ManualRestateRunner.java
+++ b/sdk-testing/src/main/java/dev/restate/sdk/testing/ManualRestateRunner.java
@@ -162,7 +162,7 @@ public class ManualRestateRunner
   public void close() {
     runtimeContainer.stop();
     LOG.debug("Stopped Restate container");
-    server.close().toCompletionStage().toCompletableFuture();
+    server.close().toCompletionStage().toCompletableFuture().join();
     LOG.debug("Stopped Embedded Service endpoint server");
   }
 

--- a/sdk-testing/src/test/java/dev/restate/sdk/testing/CounterTest.java
+++ b/sdk-testing/src/test/java/dev/restate/sdk/testing/CounterTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class CounterTest {
 
   @RegisterExtension
-  private static final RestateRunner restateRunner =
+  private static final RestateRunner RESTATE_RUNNER =
       RestateRunnerBuilder.create()
           .withRestateContainerImage(
               "ghcr.io/restatedev/restate:main") // test against the latest main Restate image


### PR DESCRIPTION
This commit updates the Java SDK to allow all completable journal entries
to have a failure variant. As part of this change, we also added tests to
ensure the correct behavior.

This fixes https://github.com/restatedev/sdk-java/issues/187.