### PR TITLE
Support Kotlin target in the protoc plugin

### DIFF
--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -40,9 +40,6 @@ val pluginJar =
 protobuf {
   plugins {
     id("grpc") { artifact = "io.grpc:protoc-gen-grpc-java:${coreLibs.versions.grpc.get()}" }
-    id("grpckt") {
-      artifact = "io.grpc:protoc-gen-grpc-kotlin:${coreLibs.versions.grpckt.get()}:jdk8@jar"
-    }
     id("restate") {
       // NOTE: This is not needed in a regular project configuration, you should rather use:
       // artifact = "dev.restate.sdk:protoc-gen-restate-java-blocking:1.0-SNAPSHOT:all@jar"
@@ -55,15 +52,12 @@ protobuf {
       it.dependsOn(":protoc-gen-restate:shadowJar")
       it.plugins {
         id("grpc")
-        id("grpckt")
-        id("restate")
+        id("restate") {
+          option("java")
+          option("kotlin")
+        }
       }
       it.builtins { id("kotlin") }
-
-      // Generate descriptor set including the imports in order to make it easier to
-      // invoke the services via grpcurl (using -protoset).
-      it.generateDescriptorSet = true
-      it.descriptorSetOptions.includeImports = true
     }
   }
 }

--- a/examples/src/main/kotlin/dev/restate/sdk/examples/CounterKt.kt
+++ b/examples/src/main/kotlin/dev/restate/sdk/examples/CounterKt.kt
@@ -8,53 +8,48 @@
 // https://github.com/restatedev/sdk-java/blob/main/LICENSE
 package dev.restate.sdk.examples
 
-import com.google.protobuf.Empty
 import dev.restate.sdk.common.CoreSerdes
 import dev.restate.sdk.common.StateKey
 import dev.restate.sdk.examples.generated.*
 import dev.restate.sdk.http.vertx.RestateHttpEndpointBuilder
-import dev.restate.sdk.kotlin.RestateKtService
-import kotlinx.coroutines.Dispatchers
+import dev.restate.sdk.kotlin.RestateContext
 import org.apache.logging.log4j.LogManager
 
-class CounterKt : CounterGrpcKt.CounterCoroutineImplBase(Dispatchers.Unconfined), RestateKtService {
+class CounterKt : CounterRestateKt.CounterRestateKtImplBase() {
 
   private val LOG = LogManager.getLogger(CounterKt::class.java)
 
   private val TOTAL = StateKey.of("total", CoreSerdes.LONG)
 
-  override suspend fun reset(request: CounterRequest): Empty {
-    restateContext().clear(TOTAL)
-    return Empty.getDefaultInstance()
+  override suspend fun reset(context: RestateContext, request: CounterRequest) {
+    context.clear(TOTAL)
   }
 
-  override suspend fun add(request: CounterAddRequest): Empty {
-    updateCounter(request.value)
-    return Empty.getDefaultInstance()
+  override suspend fun add(context: RestateContext, request: CounterAddRequest) {
+    updateCounter(context, request.value)
   }
 
-  override suspend fun get(request: CounterRequest): GetResponse {
-    return getResponse { value = getCounter() }
+  override suspend fun get(context: RestateContext, request: CounterRequest): GetResponse {
+    return getResponse { value = context.get(TOTAL) ?: 0L }
   }
 
-  override suspend fun getAndAdd(request: CounterAddRequest): CounterUpdateResult {
+  override suspend fun getAndAdd(
+      context: RestateContext,
+      request: CounterAddRequest
+  ): CounterUpdateResult {
     LOG.info("Invoked get and add with " + request.value)
-    val (old, new) = updateCounter(request.value)
+    val (old, new) = updateCounter(context, request.value)
     return counterUpdateResult {
       oldValue = old
       newValue = new
     }
   }
 
-  private suspend fun getCounter(): Long {
-    return restateContext().get(TOTAL) ?: 0L
-  }
-
-  private suspend fun updateCounter(add: Long): Pair<Long, Long> {
-    val currentValue = getCounter()
+  private suspend fun updateCounter(context: RestateContext, add: Long): Pair<Long, Long> {
+    val currentValue = context.get(TOTAL) ?: 0L
     val newValue = currentValue + add
 
-    restateContext().set(TOTAL, newValue)
+    context.set(TOTAL, newValue)
 
     return currentValue to newValue
   }

--- a/protoc-gen-restate/build.gradle.kts
+++ b/protoc-gen-restate/build.gradle.kts
@@ -7,7 +7,8 @@ plugins {
   `library-publishing-conventions`
 }
 
-description = "Protoc plugin to generate interfaces compatible with dev.restate:sdk-api"
+description =
+    "Protoc plugin to generate interfaces compatible with dev.restate:sdk-api or dev.restate:sdk-api-kotlin"
 
 dependencies {
   compileOnly(coreLibs.javax.annotation.api)
@@ -17,7 +18,7 @@ dependencies {
   implementation(project(":sdk-common"))
 }
 
-application { mainClass.set("dev.restate.sdk.gen.JavaGen") }
+application { mainClass.set("dev.restate.sdk.gen.RestateGen") }
 
 tasks.named<ShadowJar>("shadowJar") {
   // Override the default jar

--- a/protoc-gen-restate/src/main/resources/javaStub.mustache
+++ b/protoc-gen-restate/src/main/resources/javaStub.mustache
@@ -28,7 +28,7 @@ public class {{className}} {
         return new {{serviceName}}RestateClient(ctx);
     }
 
-{{{javadoc}}}
+{{{apidoc}}}
     public static final class {{serviceName}}RestateClient {
         private final RestateContext ctx;
 
@@ -48,7 +48,7 @@ public class {{className}} {
 
         {{#methods}}
         {{#deprecated}}@java.lang.Deprecated{{/deprecated}}
-{{{javadoc}}}
+{{{apidoc}}}
         public Awaitable<{{outputType}}> {{topLevelClientMethodName}}({{^isInputEmpty}}{{inputType}} request{{/isInputEmpty}}) {
             return this.ctx.call({{packageName}}.{{serviceName}}Grpc.{{methodDescriptorGetter}}(), {{#isInputEmpty}}com.google.protobuf.Empty.getDefaultInstance(){{/isInputEmpty}}{{^isInputEmpty}}request{{/isInputEmpty}});
         }
@@ -65,7 +65,7 @@ public class {{className}} {
 
         {{#methods}}
         {{#deprecated}}@java.lang.Deprecated{{/deprecated}}
-{{{javadoc}}}
+{{{apidoc}}}
         public void {{methodName}}({{^isInputEmpty}}{{inputType}} request{{/isInputEmpty}}) {
             this.ctx.oneWayCall({{packageName}}.{{serviceName}}Grpc.{{methodDescriptorGetter}}(), {{#isInputEmpty}}com.google.protobuf.Empty.getDefaultInstance(){{/isInputEmpty}}{{^isInputEmpty}}request{{/isInputEmpty}});
         }
@@ -84,7 +84,7 @@ public class {{className}} {
 
         {{#methods}}
         {{#deprecated}}@java.lang.Deprecated{{/deprecated}}
-{{{javadoc}}}
+{{{apidoc}}}
         public void {{methodName}}({{^isInputEmpty}}{{inputType}} request{{/isInputEmpty}}) {
             this.ctx.delayedCall({{packageName}}.{{serviceName}}Grpc.{{methodDescriptorGetter}}(), {{#isInputEmpty}}com.google.protobuf.Empty.getDefaultInstance(){{/isInputEmpty}}{{^isInputEmpty}}request{{/isInputEmpty}}, this.delay);
         }
@@ -92,14 +92,14 @@ public class {{className}} {
         {{/methods}}
     }
 
-{{{javadoc}}}
+{{{apidoc}}}
     public static abstract class {{serviceName}}RestateImplBase implements dev.restate.sdk.RestateService {
 
         {{#methods}}
         {{#deprecated}}
         @java.lang.Deprecated
         {{/deprecated}}
-{{{javadoc}}}
+{{{apidoc}}}
         public {{#isOutputEmpty}}void{{/isOutputEmpty}}{{^isOutputEmpty}}{{outputType}}{{/isOutputEmpty}} {{methodName}}(RestateContext context{{^isInputEmpty}}, {{inputType}} request{{/isInputEmpty}}) throws dev.restate.sdk.common.TerminalException {
             throw new dev.restate.sdk.common.TerminalException(dev.restate.sdk.common.TerminalException.Code.UNIMPLEMENTED);
         }

--- a/protoc-gen-restate/src/main/resources/ktStub.mustache
+++ b/protoc-gen-restate/src/main/resources/ktStub.mustache
@@ -1,0 +1,114 @@
+{{#packageName}}
+package {{packageName}};
+{{/packageName}}
+
+import dev.restate.sdk.kotlin.RestateContext;
+import dev.restate.sdk.kotlin.Awaitable;
+import dev.restate.sdk.kotlin.RestateKtService;
+import dev.restate.sdk.common.syscalls.Syscalls;
+import io.grpc.kotlin.ClientCalls.unaryRpc
+import io.grpc.kotlin.ServerCalls.unaryServerMethodDefinition
+import {{packageName}}.{{serviceName}}Grpc.getServiceDescriptor;
+import dev.restate.sdk.kotlin.restateContextFromSyscalls;
+import kotlin.time.Duration
+
+{{#deprecated}}
+@Deprecated
+{{/deprecated}}
+public object {{className}} {
+
+    /**
+     * Create a new client from the given [RestateContext].
+     */
+    fun newClient(ctx: RestateContext): {{serviceName}}RestateKtClient {
+        return {{serviceName}}RestateKtClient(ctx);
+    }
+
+{{{javadoc}}}
+    public class {{serviceName}}RestateKtClient(private val ctx: RestateContext) {
+        // Create a variant of this client to execute oneWay calls.
+        public fun oneWay(): {{serviceName}}RestateKtOneWayClient {
+            return {{serviceName}}RestateKtOneWayClient(ctx);
+        }
+
+        // Create a variant of this client to execute delayed calls.
+        public fun delayed(delay: Duration): {{serviceName}}RestateKtDelayedClient {
+            return {{serviceName}}RestateKtDelayedClient(ctx, delay);
+        }
+
+        {{#methods}}
+        {{#deprecated}}@Deprecated{{/deprecated}}
+{{{javadoc}}}
+        public suspend fun {{topLevelClientMethodName}}({{^isInputEmpty}}request: {{inputType}}{{/isInputEmpty}}): Awaitable<{{outputType}}> {
+            return this.ctx.callAsync({{packageName}}.{{serviceName}}Grpc.{{methodDescriptorGetter}}(), {{#isInputEmpty}}com.google.protobuf.Empty.getDefaultInstance(){{/isInputEmpty}}{{^isInputEmpty}}request{{/isInputEmpty}});
+        }
+
+        {{/methods}}
+    }
+
+    public class {{serviceName}}RestateKtOneWayClient(private val ctx: RestateContext) {
+        {{#methods}}
+        {{#deprecated}}@Deprecated{{/deprecated}}
+{{{javadoc}}}
+        public suspend fun {{methodName}}({{^isInputEmpty}}request: {{inputType}}{{/isInputEmpty}}) {
+            this.ctx.oneWayCall({{packageName}}.{{serviceName}}Grpc.{{methodDescriptorGetter}}(), {{#isInputEmpty}}com.google.protobuf.Empty.getDefaultInstance(){{/isInputEmpty}}{{^isInputEmpty}}request{{/isInputEmpty}});
+        }
+
+        {{/methods}}
+    }
+
+    public class {{serviceName}}RestateKtDelayedClient(private val ctx: RestateContext, private val delay: Duration) {
+        {{#methods}}
+        {{#deprecated}}@Deprecated{{/deprecated}}
+{{{javadoc}}}
+        public suspend fun {{methodName}}({{^isInputEmpty}}request: {{inputType}}{{/isInputEmpty}}) {
+            this.ctx.delayedCall({{packageName}}.{{serviceName}}Grpc.{{methodDescriptorGetter}}(), {{#isInputEmpty}}com.google.protobuf.Empty.getDefaultInstance(){{/isInputEmpty}}{{^isInputEmpty}}request{{/isInputEmpty}}, this.delay);
+        }
+
+        {{/methods}}
+    }
+
+{{{javadoc}}}
+    public abstract class {{serviceName}}RestateKtImplBase(
+            private val coroutineContext: kotlin.coroutines.CoroutineContext = kotlinx.coroutines.Dispatchers.Unconfined,
+        ): RestateKtService {
+
+        {{#methods}}
+        {{#deprecated}}
+        @Deprecated
+        {{/deprecated}}
+{{{javadoc}}}
+        public open suspend fun {{methodName}}(context: RestateContext{{^isInputEmpty}}, request: {{inputType}} {{/isInputEmpty}}){{^isOutputEmpty}}: {{outputType}}{{/isOutputEmpty}} {
+            throw dev.restate.sdk.common.TerminalException(dev.restate.sdk.common.TerminalException.Code.UNIMPLEMENTED);
+        }
+
+        {{/methods}}
+            final override fun bindService(): io.grpc.ServerServiceDefinition {
+            return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+                    {{#methods}}
+                    .addMethod(unaryServerMethodDefinition(
+                        context = this.coroutineContext,
+                        descriptor = {{packageName}}.{{serviceName}}Grpc.{{methodDescriptorGetter}}(),
+                        implementation = {
+                            {{#isInputEmpty}}{{#isOutputEmpty}}
+                            {{methodName}}(restateContextFromSyscalls(Syscalls.current()))
+                            return@unaryServerMethodDefinition com.google.protobuf.Empty.getDefaultInstance()
+                            {{/isOutputEmpty}}{{/isInputEmpty}}
+                            {{#isInputEmpty}}{{^isOutputEmpty}}
+                            return@unaryServerMethodDefinition {{methodName}}(restateContextFromSyscalls(Syscalls.current()))
+                            {{/isOutputEmpty}}{{/isInputEmpty}}
+                            {{^isInputEmpty}}{{#isOutputEmpty}}
+                            {{methodName}}(restateContextFromSyscalls(Syscalls.current()), it)
+                            return@unaryServerMethodDefinition com.google.protobuf.Empty.getDefaultInstance()
+                            {{/isOutputEmpty}}{{/isInputEmpty}}
+                            {{^isInputEmpty}}{{^isOutputEmpty}}
+                            return@unaryServerMethodDefinition {{methodName}}(restateContextFromSyscalls(Syscalls.current()), it)
+                            {{/isOutputEmpty}}{{/isInputEmpty}}
+                        }
+                    ))
+                    {{/methods}}
+                    .build();
+        }
+    }
+
+}

--- a/sdk-api-kotlin/build.gradle.kts
+++ b/sdk-api-kotlin/build.gradle.kts
@@ -27,19 +27,32 @@ dependencies {
   testProtobuf(project(":sdk-core", "testArchive"))
 }
 
+val pluginJar =
+    file(
+        "${project.rootProject.rootDir}/protoc-gen-restate/build/libs/protoc-gen-restate-${project.version}-all.jar")
+
 protobuf {
   plugins {
     id("grpc") { artifact = "io.grpc:protoc-gen-grpc-java:${coreLibs.versions.grpc.get()}" }
     id("grpckt") {
       artifact = "io.grpc:protoc-gen-grpc-kotlin:${coreLibs.versions.grpckt.get()}:jdk8@jar"
     }
+    id("restate") {
+      // NOTE: This is not needed in a regular project configuration, you should rather use:
+      // artifact = "dev.restate.sdk:protoc-gen-restate-java-blocking:1.0-SNAPSHOT:all@jar"
+      path = pluginJar.path
+    }
   }
 
   generateProtoTasks {
     ofSourceSet("test").forEach {
+      // Make sure we depend on shadowJar from protoc-gen-restate
+      it.dependsOn(":protoc-gen-restate:shadowJar")
+
       it.plugins {
         id("grpc")
         id("grpckt")
+        id("restate") { option("kotlin") }
       }
       it.builtins { id("kotlin") }
     }

--- a/sdk-api-kotlin/src/main/kotlin/dev/restate/sdk/kotlin/api.kt
+++ b/sdk-api-kotlin/src/main/kotlin/dev/restate/sdk/kotlin/api.kt
@@ -373,3 +373,13 @@ interface RestateKtService : NonBlockingService {
     return RestateContextImpl(Syscalls.SYSCALLS_KEY.get())
   }
 }
+
+/**
+ * Build a RestateContext from the [Syscalls] object.
+ *
+ * This method is used by code-generation, you should not use it directly but rather use
+ * [RestateKtService.restateContext].
+ */
+fun restateContextFromSyscalls(syscalls: Syscalls): RestateContext {
+  return RestateContextImpl(syscalls)
+}

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/KotlinCoroutinesTests.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/KotlinCoroutinesTests.kt
@@ -32,6 +32,7 @@ class KotlinCoroutinesTests : TestRunner() {
         SleepTest(),
         StateMachineFailuresTest(),
         UserFailuresTest(),
+        RestateCodegenTest(),
         RandomTest())
   }
 }

--- a/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/RestateCodegenTest.kt
+++ b/sdk-api-kotlin/src/test/kotlin/dev/restate/sdk/kotlin/RestateCodegenTest.kt
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate Java SDK,
+// which is released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/sdk-java/blob/main/LICENSE
+package dev.restate.sdk.kotlin
+
+import dev.restate.sdk.core.RestateCodegenTestSuite
+import dev.restate.sdk.core.testservices.*
+import dev.restate.sdk.core.testservices.CodegenRestateKt.CodegenRestateKtImplBase
+import dev.restate.sdk.core.testservices.GreeterRestateKt.GreeterRestateKtImplBase
+import io.grpc.BindableService
+import kotlin.time.Duration.Companion.seconds
+
+class RestateCodegenTest : RestateCodegenTestSuite() {
+  private class GreeterWithRestateClientAndServerCodegen : GreeterRestateKtImplBase() {
+    override suspend fun greet(
+        context: RestateContext,
+        request: GreetingRequest
+    ): GreetingResponse {
+      val client = GreeterRestateKt.newClient(context)
+      client.delayed(1.seconds).greet(request)
+      client.oneWay().greet(request)
+      return client.greet(request).await()
+    }
+  }
+
+  override fun greeterWithRestateClientAndServerCodegen(): BindableService {
+    return GreeterWithRestateClientAndServerCodegen()
+  }
+
+  private class Codegen : CodegenRestateKtImplBase() {
+    override suspend fun emptyInput(context: RestateContext): MyMessage {
+      val client = CodegenRestateKt.newClient(context)
+      return client.emptyInput().await()
+    }
+
+    override suspend fun emptyOutput(context: RestateContext, request: MyMessage) {
+      val client = CodegenRestateKt.newClient(context)
+      client.emptyOutput(request).await()
+    }
+
+    override suspend fun emptyInputOutput(context: RestateContext) {
+      val client = CodegenRestateKt.newClient(context)
+      client.emptyInputOutput().await()
+    }
+
+    override suspend fun oneWay(context: RestateContext, request: MyMessage): MyMessage {
+      val client = CodegenRestateKt.newClient(context)
+      return client._oneWay(request).await()
+    }
+
+    override suspend fun delayed(context: RestateContext, request: MyMessage): MyMessage {
+      val client = CodegenRestateKt.newClient(context)
+      return client._delayed(request).await()
+    }
+  }
+
+  override fun codegen(): BindableService {
+    return Codegen()
+  }
+}

--- a/sdk-core/src/test/java/dev/restate/sdk/core/RestateCodegenTestSuite.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/RestateCodegenTestSuite.java
@@ -1,0 +1,121 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate Java SDK,
+// which is released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/sdk-java/blob/main/LICENSE
+package dev.restate.sdk.core;
+
+import static dev.restate.sdk.core.ProtoUtils.*;
+import static dev.restate.sdk.core.TestDefinitions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+
+import com.google.protobuf.Empty;
+import dev.restate.generated.service.protocol.Protocol;
+import dev.restate.sdk.core.testservices.*;
+import io.grpc.BindableService;
+import java.util.stream.Stream;
+
+public abstract class RestateCodegenTestSuite implements TestSuite {
+
+  protected abstract BindableService greeterWithRestateClientAndServerCodegen();
+
+  protected abstract BindableService codegen();
+
+  @Override
+  public Stream<TestDefinition> definitions() {
+    return Stream.of(
+        testInvocation(this::greeterWithRestateClientAndServerCodegen, GreeterGrpc.getGreetMethod())
+            .withInput(
+                startMessage(1),
+                inputMessage(greetingRequest("Francesco")),
+                completionMessage(3, greetingResponse("Till")))
+            .onlyUnbuffered()
+            .assertingOutput(
+                msgs -> {
+                  assertThat(msgs)
+                      .element(0)
+                      .asInstanceOf(type(Protocol.BackgroundInvokeEntryMessage.class))
+                      .satisfies(
+                          backgroundInvokeEntryMessage -> {
+                            // Check invoke time is non zero
+                            assertThat(backgroundInvokeEntryMessage.getInvokeTime())
+                                .isGreaterThan(0);
+                            // Check background invoke header
+                            assertThat(
+                                    backgroundInvokeEntryMessage.toBuilder()
+                                        .clearInvokeTime()
+                                        .build())
+                                .isEqualTo(
+                                    backgroundInvokeMessage(
+                                            GreeterGrpc.getGreetMethod(),
+                                            greetingRequest("Francesco"))
+                                        .build());
+                          });
+                  assertThat(msgs)
+                      .elements(1, 2, 3, 4)
+                      .containsExactly(
+                          backgroundInvokeMessage(
+                                  GreeterGrpc.getGreetMethod(), greetingRequest("Francesco"))
+                              .build(),
+                          invokeMessage(GreeterGrpc.getGreetMethod(), greetingRequest("Francesco"))
+                              .build(),
+                          outputMessage(greetingResponse("Till")),
+                          END_MESSAGE);
+                }),
+        testInvocation(this::codegen, CodegenGrpc.getEmptyInputMethod())
+            .withInput(
+                startMessage(1),
+                inputMessage(Empty.getDefaultInstance()),
+                completionMessage(1, MyMessage.newBuilder().setValue("Francesco")))
+            .onlyUnbuffered()
+            .expectingOutput(
+                invokeMessage(CodegenGrpc.getEmptyInputMethod(), Empty.getDefaultInstance()),
+                outputMessage(MyMessage.newBuilder().setValue("Francesco")),
+                END_MESSAGE)
+            .named("Check Codegen::EmptyInput method is correctly generated"),
+        testInvocation(this::codegen, CodegenGrpc.getEmptyOutputMethod())
+            .withInput(
+                startMessage(1),
+                inputMessage(MyMessage.newBuilder().setValue("Francesco")),
+                completionMessage(1, Empty.getDefaultInstance()))
+            .onlyUnbuffered()
+            .expectingOutput(
+                invokeMessage(
+                    CodegenGrpc.getEmptyOutputMethod(),
+                    MyMessage.newBuilder().setValue("Francesco").build()),
+                outputMessage(Empty.getDefaultInstance()),
+                END_MESSAGE)
+            .named("Check Codegen::EmptyOutput method is correctly generated"),
+        testInvocation(this::codegen, CodegenGrpc.getEmptyInputOutputMethod())
+            .withInput(
+                startMessage(1),
+                inputMessage(Empty.getDefaultInstance()),
+                completionMessage(1, Empty.getDefaultInstance()))
+            .onlyUnbuffered()
+            .expectingOutput(
+                invokeMessage(CodegenGrpc.getEmptyInputOutputMethod(), Empty.getDefaultInstance()),
+                outputMessage(Empty.getDefaultInstance()),
+                END_MESSAGE)
+            .named("Check Codegen::EmptyInputOutput method is correctly generated"),
+        testInvocation(this::codegen, CodegenGrpc.getOneWayMethod())
+            .withInput(startMessage(1), inputMessage(MyMessage.newBuilder().setValue("Francesco")))
+            .expectingOutput(
+                invokeMessage(
+                    CodegenGrpc.getOneWayMethod(),
+                    MyMessage.newBuilder().setValue("Francesco").build()),
+                suspensionMessage(1))
+            .named("Check Codegen::OneWay method is correctly generated"),
+        testInvocation(this::codegen, CodegenGrpc.getDelayedMethod())
+            .withInput(startMessage(1), inputMessage(MyMessage.newBuilder().setValue("Francesco")))
+            .expectingOutput(
+                invokeMessage(
+                    CodegenGrpc.getDelayedMethod(),
+                    MyMessage.newBuilder().setValue("Francesco").build()),
+                suspensionMessage(1))
+            .named("Check Codegen::Delayed method is correctly generated"));
+  }
+}


### PR DESCRIPTION
Align the java API experience with the kotlin api by supporting code generation with kotlin as target. Fix #191