### PR TITLE
Use target/source compatibility rather than selecting a specific toolchain

### DIFF
--- a/admin-client/build.gradle.kts
+++ b/admin-client/build.gradle.kts
@@ -47,9 +47,6 @@ tasks.withType<GenerateTask> {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-  targetCompatibility = "11"
-  sourceCompatibility = "11"
-
   // Disable errorprone for this module
   options.errorprone.disableAllChecks.set(true)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,8 +88,10 @@ subprojects {
 
   dependencies { errorprone("com.google.errorprone:error_prone_core:2.13.1") }
 
+  // Configure the java toolchain to use. If not found, it will be downloaded automatically
   java {
     toolchain { languageVersion = JavaLanguageVersion.of(11) }
+
     withJavadocJar()
     withSourcesJar()
   }
@@ -97,9 +99,6 @@ subprojects {
   protobuf { protoc { artifact = "com.google.protobuf:protoc:$protobufVersion" } }
 
   tasks.withType<JavaCompile>().configureEach {
-    targetCompatibility = "11"
-    sourceCompatibility = "11"
-
     options.errorprone.disableWarningsInGeneratedCode.set(true)
     options.errorprone.disable(
         // We use toString() in proto messages for debugging reasons.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,8 @@
 
 rootProject.name = "sdk-java"
 
+plugins { id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0" }
+
 include(
     "sdk-common",
     "sdk-api",


### PR DESCRIPTION
This fixes https://github.com/restatedev/e2e/issues/237 for the sdk project