### PR TITLE
Fix usage of IngressClient in code generated by kotlin gen

### DIFF
--- a/sdk-api-kotlin-gen/src/main/resources/templates/Client.hbs
+++ b/sdk-api-kotlin-gen/src/main/resources/templates/Client.hbs
@@ -6,7 +6,8 @@ import dev.restate.sdk.common.StateKey
 import dev.restate.sdk.common.Serde
 import dev.restate.sdk.common.Target
 import kotlin.time.Duration
-import kotlinx.coroutines.future.await
+import dev.restate.sdk.kotlin.callSuspend
+import dev.restate.sdk.kotlin.sendSuspend
 
 object {{generatedClassSimpleName}} {
 
@@ -59,12 +60,12 @@ object {{generatedClassSimpleName}} {
 
         {{#handlers}}
         suspend fun {{name}}({{^inputEmpty}}req: {{{inputFqcn}}}, {{/inputEmpty}}requestOptions: dev.restate.sdk.client.RequestOptions = dev.restate.sdk.client.RequestOptions.DEFAULT): {{{boxedOutputFqcn}}} {
-            return this.ingressClient.callAsync(
+            return this.ingressClient.callSuspend(
                 {{#if isObject}}Target.virtualObject(COMPONENT_NAME, this.key, "{{name}}"){{else}}Target.service(COMPONENT_NAME, "{{name}}"){{/if}},
                 {{inputSerdeFieldName}},
                 {{outputSerdeFieldName}},
-                {{#if inputEmpty}}null{{else}}req{{/if}},
-                requestOptions).await();
+                {{#if inputEmpty}}Unit{{else}}req{{/if}},
+                requestOptions);
         }{{/handlers}}
 
         fun send(): Send {
@@ -74,11 +75,11 @@ object {{generatedClassSimpleName}} {
         inner class Send {
             {{#handlers}}
             suspend fun {{name}}({{^inputEmpty}}req: {{{inputFqcn}}}, {{/inputEmpty}}requestOptions: dev.restate.sdk.client.RequestOptions = dev.restate.sdk.client.RequestOptions.DEFAULT): String {
-                return this@IngressClient.ingressClient.sendAsync(
+                return this@IngressClient.ingressClient.sendSuspend(
                     {{#if isObject}}Target.virtualObject(COMPONENT_NAME, this@IngressClient.key, "{{name}}"){{else}}Target.service(COMPONENT_NAME, "{{name}}"){{/if}},
                     {{inputSerdeFieldName}},
-                    {{#if inputEmpty}}null{{else}}req{{/if}},
-                    requestOptions).await();
+                    {{#if inputEmpty}}Unit{{else}}req{{/if}},
+                    requestOptions);
             }{{/handlers}}
         }
     }

--- a/sdk-api-kotlin/src/main/kotlin/dev/restate/sdk/kotlin/ingress.kt
+++ b/sdk-api-kotlin/src/main/kotlin/dev/restate/sdk/kotlin/ingress.kt
@@ -1,0 +1,44 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate Java SDK,
+// which is released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/sdk-java/blob/main/LICENSE
+package dev.restate.sdk.kotlin
+
+import dev.restate.sdk.client.IngressClient
+import dev.restate.sdk.client.RequestOptions
+import dev.restate.sdk.common.Serde
+import dev.restate.sdk.common.Target
+import kotlinx.coroutines.future.await
+
+// Extension methods for the IngressClient
+
+suspend fun <Req, Res> IngressClient.callSuspend(
+    target: Target,
+    reqSerde: Serde<Req>,
+    resSerde: Serde<Res>,
+    req: Req,
+    options: RequestOptions = RequestOptions.DEFAULT
+): Res {
+  return this.callAsync(target, reqSerde, resSerde, req, options).await()
+}
+
+suspend fun <Req> IngressClient.sendSuspend(
+    target: Target,
+    reqSerde: Serde<Req>,
+    req: Req,
+    options: RequestOptions = RequestOptions.DEFAULT
+): String {
+  return this.sendAsync(target, reqSerde, req, options).await()
+}
+
+suspend fun <T> IngressClient.AwakeableHandle.resolveSuspend(serde: Serde<T>, payload: T) {
+  this.resolveAsync(serde, payload).await()
+}
+
+suspend fun IngressClient.AwakeableHandle.rejectSuspend(reason: String) {
+  this.rejectAsync(reason).await()
+}


### PR DESCRIPTION
This removes the need for the explicit `kotlinx` dependency, as https://github.com/restatedev/examples/pull/117