### PR TITLE
Integrate Java SDK with new service protocol negotiation mechanism

### DIFF
--- a/sdk-core/build.gradle.kts
+++ b/sdk-core/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
   // We need this for the manifest
   implementation(platform(jacksonLibs.jackson.bom))
   implementation(jacksonLibs.jackson.annotations)
+  implementation(jacksonLibs.jackson.databind)
 
   // We don't want a hard-dependency on it
   compileOnly(coreLibs.log4j.core)

--- a/sdk-core/build.gradle.kts
+++ b/sdk-core/build.gradle.kts
@@ -43,7 +43,7 @@ sourceSets {
 
 // Configure jsonSchema2Pojo
 jsonSchema2Pojo {
-  setSource(files("$projectDir/src/main/service-protocol/deployment_manifest_schema.json"))
+  setSource(files("$projectDir/src/main/service-protocol/endpoint_manifest_schema.json"))
   targetPackage = "dev.restate.sdk.core.manifest"
   targetDirectory = generatedJ2SPDir.get().asFile
 

--- a/sdk-core/src/main/java/dev/restate/sdk/core/DeploymentManifest.java
+++ b/sdk-core/src/main/java/dev/restate/sdk/core/DeploymentManifest.java
@@ -8,6 +8,9 @@
 // https://github.com/restatedev/sdk-java/blob/main/LICENSE
 package dev.restate.sdk.core;
 
+import static dev.restate.sdk.core.ServiceProtocol.MAX_SERVICE_PROTOCOL_VERSION;
+import static dev.restate.sdk.core.ServiceProtocol.MIN_SERVICE_PROTOCOL_VERSION;
+
 import dev.restate.sdk.common.HandlerType;
 import dev.restate.sdk.common.ServiceType;
 import dev.restate.sdk.common.syscalls.HandlerDefinition;
@@ -18,6 +21,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 final class DeploymentManifest {
+
   private static final Input EMPTY_INPUT = new Input();
   private static final Output EMPTY_OUTPUT = new Output().withSetContentTypeIfEmpty(false);
 
@@ -27,8 +31,8 @@ final class DeploymentManifest {
       DeploymentManifestSchema.ProtocolMode protocolMode, Stream<ServiceDefinition<?>> components) {
     this.manifest =
         new DeploymentManifestSchema()
-            .withMinProtocolVersion(1)
-            .withMaxProtocolVersion(1)
+            .withMinProtocolVersion(MIN_SERVICE_PROTOCOL_VERSION.getNumber())
+            .withMaxProtocolVersion(MAX_SERVICE_PROTOCOL_VERSION.getNumber())
             .withProtocolMode(protocolMode)
             .withServices(
                 components

--- a/sdk-core/src/main/java/dev/restate/sdk/core/EndpointManifest.java
+++ b/sdk-core/src/main/java/dev/restate/sdk/core/EndpointManifest.java
@@ -20,17 +20,17 @@ import dev.restate.sdk.core.manifest.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-final class DeploymentManifest {
+final class EndpointManifest {
 
   private static final Input EMPTY_INPUT = new Input();
   private static final Output EMPTY_OUTPUT = new Output().withSetContentTypeIfEmpty(false);
 
-  private final DeploymentManifestSchema manifest;
+  private final EndpointManifestSchema manifest;
 
-  public DeploymentManifest(
-      DeploymentManifestSchema.ProtocolMode protocolMode, Stream<ServiceDefinition<?>> components) {
+  public EndpointManifest(
+      EndpointManifestSchema.ProtocolMode protocolMode, Stream<ServiceDefinition<?>> components) {
     this.manifest =
-        new DeploymentManifestSchema()
+        new EndpointManifestSchema()
             .withMinProtocolVersion(MIN_SERVICE_PROTOCOL_VERSION.getNumber())
             .withMaxProtocolVersion(MAX_SERVICE_PROTOCOL_VERSION.getNumber())
             .withProtocolMode(protocolMode)
@@ -43,12 +43,12 @@ final class DeploymentManifest {
                                 .withTy(convertServiceType(svc.getServiceType()))
                                 .withHandlers(
                                     svc.getHandlers().stream()
-                                        .map(DeploymentManifest::convertHandler)
+                                        .map(EndpointManifest::convertHandler)
                                         .collect(Collectors.toList())))
                     .collect(Collectors.toList()));
   }
 
-  public DeploymentManifestSchema manifest() {
+  public EndpointManifestSchema manifest() {
     return this.manifest;
   }
 

--- a/sdk-core/src/main/java/dev/restate/sdk/core/InvocationStateMachine.java
+++ b/sdk-core/src/main/java/dev/restate/sdk/core/InvocationStateMachine.java
@@ -135,7 +135,6 @@ class InvocationStateMachine implements InvocationFlow.InvocationProcessor {
     MessageLite msg = invocationInput.message();
     LOG.trace("Received input message {} {}", msg.getClass(), msg);
     if (this.invocationState == InvocationState.WAITING_START) {
-      MessageHeader.checkProtocolVersion(invocationInput.header());
       this.onStartMessage(msg);
     } else if (msg instanceof Protocol.CompletionMessage) {
       // We check the instance rather than the state, because the user code might still be

--- a/sdk-core/src/main/java/dev/restate/sdk/core/MessageHeader.java
+++ b/sdk-core/src/main/java/dev/restate/sdk/core/MessageHeader.java
@@ -13,9 +13,6 @@ import dev.restate.generated.service.protocol.Protocol;
 
 public class MessageHeader {
 
-  static final short SUPPORTED_PROTOCOL_VERSION = 2;
-
-  static final short VERSION_MASK = 0x03FF;
   static final short DONE_FLAG = 0x0001;
   static final int REQUIRES_ACK_FLAG = 0x8000;
 
@@ -100,21 +97,5 @@ public class MessageHeader {
     }
     // Messages with no flags
     return new MessageHeader(MessageType.fromMessage(msg), 0, msg.getSerializedSize());
-  }
-
-  public static void checkProtocolVersion(MessageHeader header) {
-    if (header.type != MessageType.StartMessage) {
-      throw new IllegalStateException("Expected StartMessage, got " + header.type);
-    }
-
-    short version = (short) (header.flags & VERSION_MASK);
-    if (version != SUPPORTED_PROTOCOL_VERSION) {
-      throw new IllegalStateException(
-          "Unsupported protocol version "
-              + version
-              + ", only version "
-              + SUPPORTED_PROTOCOL_VERSION
-              + " is supported");
-    }
   }
 }

--- a/sdk-core/src/main/java/dev/restate/sdk/core/RestateEndpoint.java
+++ b/sdk-core/src/main/java/dev/restate/sdk/core/RestateEndpoint.java
@@ -12,7 +12,7 @@ import dev.restate.sdk.auth.RequestIdentityVerifier;
 import dev.restate.sdk.common.BindableServiceFactory;
 import dev.restate.sdk.common.syscalls.HandlerDefinition;
 import dev.restate.sdk.common.syscalls.ServiceDefinition;
-import dev.restate.sdk.core.manifest.DeploymentManifestSchema;
+import dev.restate.sdk.core.manifest.EndpointManifestSchema;
 import dev.restate.sdk.core.manifest.Service;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
@@ -34,10 +34,10 @@ public class RestateEndpoint {
   private final Map<String, ServiceAndOptions<?>> services;
   private final Tracer tracer;
   private final RequestIdentityVerifier requestIdentityVerifier;
-  private final DeploymentManifest deploymentManifest;
+  private final EndpointManifest deploymentManifest;
 
   private RestateEndpoint(
-      DeploymentManifestSchema.ProtocolMode protocolMode,
+      EndpointManifestSchema.ProtocolMode protocolMode,
       Map<String, ServiceAndOptions<?>> services,
       Tracer tracer,
       RequestIdentityVerifier requestIdentityVerifier) {
@@ -45,7 +45,7 @@ public class RestateEndpoint {
     this.tracer = tracer;
     this.requestIdentityVerifier = requestIdentityVerifier;
     this.deploymentManifest =
-        new DeploymentManifest(protocolMode, services.values().stream().map(c -> c.service));
+        new EndpointManifest(protocolMode, services.values().stream().map(c -> c.service));
 
     this.logCreation();
   }
@@ -99,8 +99,8 @@ public class RestateEndpoint {
     return new ResolvedEndpointHandlerImpl(stateMachine, handler, svc.options, syscallExecutor);
   }
 
-  public DeploymentManifestSchema handleDiscoveryRequest() {
-    DeploymentManifestSchema response = this.deploymentManifest.manifest();
+  public EndpointManifestSchema handleDiscoveryRequest() {
+    EndpointManifestSchema response = this.deploymentManifest.manifest();
     LOG.info(
         "Replying to discovery request with services [{}]",
         response.getServices().stream().map(Service::getName).collect(Collectors.joining(",")));
@@ -113,18 +113,18 @@ public class RestateEndpoint {
 
   // -- Builder
 
-  public static Builder newBuilder(DeploymentManifestSchema.ProtocolMode protocolMode) {
+  public static Builder newBuilder(EndpointManifestSchema.ProtocolMode protocolMode) {
     return new Builder(protocolMode);
   }
 
   public static class Builder {
 
     private final List<ServiceAndOptions<?>> services = new ArrayList<>();
-    private final DeploymentManifestSchema.ProtocolMode protocolMode;
+    private final EndpointManifestSchema.ProtocolMode protocolMode;
     private RequestIdentityVerifier requestIdentityVerifier;
     private Tracer tracer = OpenTelemetry.noop().getTracer("NOOP");
 
-    public Builder(DeploymentManifestSchema.ProtocolMode protocolMode) {
+    public Builder(EndpointManifestSchema.ProtocolMode protocolMode) {
       this.protocolMode = protocolMode;
     }
 

--- a/sdk-core/src/main/java/dev/restate/sdk/core/ServiceProtocol.java
+++ b/sdk-core/src/main/java/dev/restate/sdk/core/ServiceProtocol.java
@@ -11,7 +11,7 @@ package dev.restate.sdk.core;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.restate.generated.service.discovery.Discovery;
 import dev.restate.generated.service.protocol.Protocol;
-import dev.restate.sdk.core.manifest.DeploymentManifestSchema;
+import dev.restate.sdk.core.manifest.EndpointManifestSchema;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -40,7 +40,8 @@ public class ServiceProtocol {
     if (Objects.requireNonNull(version) == Protocol.ServiceProtocolVersion.V1) {
       return "application/vnd.restate.invocation.v1";
     }
-    throw new IllegalArgumentException(String.format("Service protocol version '%s' has no header value", version.getNumber()));
+    throw new IllegalArgumentException(
+        String.format("Service protocol version '%s' has no header value", version.getNumber()));
   }
 
   public static boolean is_supported(Protocol.ServiceProtocolVersion serviceProtocolVersion) {
@@ -60,8 +61,8 @@ public class ServiceProtocol {
    * Selects the highest supported service protocol version from a list of supported versions.
    *
    * @param acceptedVersionsString A comma-separated list of accepted service protocol versions.
-   * @return The highest supported service protocol version, otherwise {@link
-   *     Protocol.ServiceProtocolVersion.SERVICE_PROTOCOL_VERSION_UNSPECIFIED}
+   * @return The highest supported service protocol version, otherwise
+   *     Protocol.ServiceProtocolVersion.SERVICE_PROTOCOL_VERSION_UNSPECIFIED
    */
   public static Discovery.ServiceDiscoveryProtocolVersion
       selectSupportedServiceDiscoveryProtocolVersion(String acceptedVersionsString) {
@@ -105,7 +106,9 @@ public class ServiceProtocol {
     if (Objects.requireNonNull(version) == Discovery.ServiceDiscoveryProtocolVersion.V1) {
       return "application/vnd.restate.endpointmanifest.v1+json";
     }
-    throw new IllegalArgumentException(String.format("Service discovery protocol version '%s' has no header value", version.getNumber()));
+    throw new IllegalArgumentException(
+        String.format(
+            "Service discovery protocol version '%s' has no header value", version.getNumber()));
   }
 
   public static class DiscoveryResponseSerializer {
@@ -122,7 +125,7 @@ public class ServiceProtocol {
       this.serviceDiscoveryProtocolVersion = serviceDiscoveryProtocolVersion;
     }
 
-    public byte[] serialize(DeploymentManifestSchema response) throws Exception {
+    public byte[] serialize(EndpointManifestSchema response) throws Exception {
       if (this.serviceDiscoveryProtocolVersion == Discovery.ServiceDiscoveryProtocolVersion.V1) {
         return MANIFEST_OBJECT_MAPPER.writeValueAsBytes(response);
       }

--- a/sdk-core/src/main/java/dev/restate/sdk/core/ServiceProtocol.java
+++ b/sdk-core/src/main/java/dev/restate/sdk/core/ServiceProtocol.java
@@ -1,0 +1,136 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate Java SDK,
+// which is released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/sdk-java/blob/main/LICENSE
+package dev.restate.sdk.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.restate.generated.service.discovery.Discovery;
+import dev.restate.generated.service.protocol.Protocol;
+import dev.restate.sdk.core.manifest.DeploymentManifestSchema;
+import java.util.Objects;
+import java.util.Optional;
+
+public class ServiceProtocol {
+  public static final Protocol.ServiceProtocolVersion MIN_SERVICE_PROTOCOL_VERSION =
+      Protocol.ServiceProtocolVersion.V1;
+  public static final Protocol.ServiceProtocolVersion MAX_SERVICE_PROTOCOL_VERSION =
+      Protocol.ServiceProtocolVersion.V1;
+
+  public static final Discovery.ServiceDiscoveryProtocolVersion
+      MIN_SERVICE_DISCOVERY_PROTOCOL_VERSION = Discovery.ServiceDiscoveryProtocolVersion.V1;
+  public static final Discovery.ServiceDiscoveryProtocolVersion
+      MAX_SERVICE_DISCOVERY_PROTOCOL_VERSION = Discovery.ServiceDiscoveryProtocolVersion.V1;
+
+  public static Protocol.ServiceProtocolVersion parseServiceProtocolVersion(String version) {
+    version = version.trim();
+
+    if (version.equals("application/vnd.restate.invocation.v1")) {
+      return Protocol.ServiceProtocolVersion.V1;
+    }
+    return Protocol.ServiceProtocolVersion.SERVICE_PROTOCOL_VERSION_UNSPECIFIED;
+  }
+
+  public static String serviceProtocolVersionToHeaderValue(
+      Protocol.ServiceProtocolVersion version) {
+    if (Objects.requireNonNull(version) == Protocol.ServiceProtocolVersion.V1) {
+      return "application/vnd.restate.invocation.v1";
+    }
+    throw new IllegalArgumentException(String.format("Service protocol version '%s' has no header value", version.getNumber()));
+  }
+
+  public static boolean is_supported(Protocol.ServiceProtocolVersion serviceProtocolVersion) {
+    return MIN_SERVICE_PROTOCOL_VERSION.getNumber() <= serviceProtocolVersion.getNumber()
+        && serviceProtocolVersion.getNumber() <= MAX_SERVICE_PROTOCOL_VERSION.getNumber();
+  }
+
+  public static boolean is_supported(
+      Discovery.ServiceDiscoveryProtocolVersion serviceDiscoveryProtocolVersion) {
+    return MIN_SERVICE_DISCOVERY_PROTOCOL_VERSION.getNumber()
+            <= serviceDiscoveryProtocolVersion.getNumber()
+        && serviceDiscoveryProtocolVersion.getNumber()
+            <= MAX_SERVICE_DISCOVERY_PROTOCOL_VERSION.getNumber();
+  }
+
+  /**
+   * Selects the highest supported service protocol version from a list of supported versions.
+   *
+   * @param acceptedVersionsString A comma-separated list of accepted service protocol versions.
+   * @return The highest supported service protocol version, otherwise {@link
+   *     Protocol.ServiceProtocolVersion.SERVICE_PROTOCOL_VERSION_UNSPECIFIED}
+   */
+  public static Discovery.ServiceDiscoveryProtocolVersion
+      selectSupportedServiceDiscoveryProtocolVersion(String acceptedVersionsString) {
+    // assume V1 in case nothing was set
+    if (acceptedVersionsString == null || acceptedVersionsString.isEmpty()) {
+      return Discovery.ServiceDiscoveryProtocolVersion.V1;
+    }
+
+    final String[] supportedVersions = acceptedVersionsString.split(",");
+
+    Discovery.ServiceDiscoveryProtocolVersion maxVersion =
+        Discovery.ServiceDiscoveryProtocolVersion.SERVICE_DISCOVERY_PROTOCOL_VERSION_UNSPECIFIED;
+
+    for (String versionString : supportedVersions) {
+      final Optional<Discovery.ServiceDiscoveryProtocolVersion> optionalVersion =
+          parseServiceDiscoveryProtocolVersion(versionString);
+
+      if (optionalVersion.isPresent()) {
+        final Discovery.ServiceDiscoveryProtocolVersion version = optionalVersion.get();
+        if (is_supported(version) && version.getNumber() > maxVersion.getNumber()) {
+          maxVersion = version;
+        }
+      }
+    }
+
+    return maxVersion;
+  }
+
+  public static Optional<Discovery.ServiceDiscoveryProtocolVersion>
+      parseServiceDiscoveryProtocolVersion(String versionString) {
+    versionString = versionString.trim();
+
+    if (versionString.equals("application/vnd.restate.endpointmanifest.v1+json")) {
+      return Optional.of(Discovery.ServiceDiscoveryProtocolVersion.V1);
+    }
+    return Optional.empty();
+  }
+
+  public static String serviceDiscoveryProtocolVersionToHeaderValue(
+      Discovery.ServiceDiscoveryProtocolVersion version) {
+    if (Objects.requireNonNull(version) == Discovery.ServiceDiscoveryProtocolVersion.V1) {
+      return "application/vnd.restate.endpointmanifest.v1+json";
+    }
+    throw new IllegalArgumentException(String.format("Service discovery protocol version '%s' has no header value", version.getNumber()));
+  }
+
+  public static class DiscoveryResponseSerializer {
+    private static final ObjectMapper MANIFEST_OBJECT_MAPPER = new ObjectMapper();
+
+    private final Discovery.ServiceDiscoveryProtocolVersion serviceDiscoveryProtocolVersion;
+
+    public DiscoveryResponseSerializer(
+        Discovery.ServiceDiscoveryProtocolVersion serviceDiscoveryProtocolVersion) {
+      if (!is_supported(serviceDiscoveryProtocolVersion)) {
+        throw new IllegalArgumentException("Unsupported service discovery protocol version");
+      }
+
+      this.serviceDiscoveryProtocolVersion = serviceDiscoveryProtocolVersion;
+    }
+
+    public byte[] serialize(DeploymentManifestSchema response) throws Exception {
+      if (this.serviceDiscoveryProtocolVersion == Discovery.ServiceDiscoveryProtocolVersion.V1) {
+        return MANIFEST_OBJECT_MAPPER.writeValueAsBytes(response);
+      }
+
+      throw new IllegalStateException(
+          String.format(
+              "DiscoveryResponseSerializer does not support service discovery protocol '%s'",
+              this.serviceDiscoveryProtocolVersion.getNumber()));
+    }
+  }
+}

--- a/sdk-core/src/main/service-protocol/README.md
+++ b/sdk-core/src/main/service-protocol/README.md
@@ -8,6 +8,6 @@ This repo contains specification documents and Protobuf schemas of the Restate S
 
 To format the spec document:
 
-```
+```shell
 npx prettier -w service-invocation-protocol.md
 ```

--- a/sdk-core/src/main/service-protocol/dev/restate/service/discovery.proto
+++ b/sdk-core/src/main/service-protocol/dev/restate/service/discovery.proto
@@ -1,0 +1,22 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/service-protocol/blob/main/LICENSE
+
+syntax = "proto3";
+
+package dev.restate.service.discovery;
+
+option java_package = "dev.restate.generated.service.discovery";
+option go_package = "restate.dev/sdk-go/pb/service/discovery";
+
+// Service discovery protocol version.
+enum ServiceDiscoveryProtocolVersion {
+  SERVICE_DISCOVERY_PROTOCOL_VERSION_UNSPECIFIED = 0;
+  // initial service discovery protocol version using endpoint_manifest_schema.json
+  V1 = 1;
+}

--- a/sdk-core/src/main/service-protocol/dev/restate/service/protocol.proto
+++ b/sdk-core/src/main/service-protocol/dev/restate/service/protocol.proto
@@ -14,6 +14,13 @@ package dev.restate.service.protocol;
 option java_package = "dev.restate.generated.service.protocol";
 option go_package = "restate.dev/sdk-go/pb/service/protocol";
 
+// Service protocol version.
+enum ServiceProtocolVersion {
+  SERVICE_PROTOCOL_VERSION_UNSPECIFIED = 0;
+  // initial service protocol version
+  V1 = 1;
+}
+
 // --- Core frames ---
 
 // Type: 0x0000 + 0
@@ -195,6 +202,60 @@ message GetStateKeysEntryMessage {
     StateKeys value = 14;
     Failure failure = 15;
   };
+
+  // Entry name
+  string name = 12;
+}
+
+// Completable: Yes
+// Fallible: No
+// Type: 0x0800 + 8
+message GetPromiseEntryMessage {
+  string key = 1;
+
+  oneof result {
+    bytes value = 14;
+    Failure failure = 15;
+  };
+
+  // Entry name
+  string name = 12;
+}
+
+// Completable: Yes
+// Fallible: No
+// Type: 0x0800 + 9
+message PeekPromiseEntryMessage {
+  string key = 1;
+
+  oneof result {
+    Empty empty = 13;
+    bytes value = 14;
+    Failure failure = 15;
+  };
+
+  // Entry name
+  string name = 12;
+}
+
+// Completable: Yes
+// Fallible: No
+// Type: 0x0800 + A
+message CompletePromiseEntryMessage {
+  string key = 1;
+
+  // The value to use to complete the promise
+  oneof completion {
+    bytes completion_value = 2;
+    Failure completion_failure = 3;
+  };
+
+  oneof result {
+    // Returns empty if value was set successfully
+    Empty empty = 13;
+    // Returns a failure if the promise was already completed
+    Failure failure = 15;
+  }
 
   // Entry name
   string name = 12;

--- a/sdk-core/src/main/service-protocol/endpoint_manifest_schema.json
+++ b/sdk-core/src/main/service-protocol/endpoint_manifest_schema.json
@@ -1,9 +1,9 @@
 {
-  "$id": "https://restate.dev/deployment.manifest.json",
+  "$id": "https://restate.dev/endpoint.manifest.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "title": "Deployment",
-  "description": "Restate deployment manifest",
+  "title": "Endpoint",
+  "description": "Restate endpoint manifest v1",
   "properties": {
     "protocolMode": {
       "title": "ProtocolMode",
@@ -11,11 +11,15 @@
     },
     "minProtocolVersion": {
       "type": "integer",
-      "minimum": 0
+      "minimum": 1,
+      "maximum": 2147483647,
+      "description": "Minimum supported protocol version"
     },
     "maxProtocolVersion": {
       "type": "integer",
-      "maximum": 0
+      "minimum": 1,
+      "maximum": 2147483647,
+      "description": "Maximum supported protocol version"
     },
     "services": {
       "type": "array",
@@ -29,7 +33,7 @@
           },
           "ty": {
             "title": "ServiceType",
-            "enum": ["VIRTUAL_OBJECT", "SERVICE"]
+            "enum": ["VIRTUAL_OBJECT", "SERVICE", "WORKFLOW"]
           },
           "handlers": {
             "type": "array",
@@ -43,8 +47,8 @@
                 },
                 "ty": {
                   "title": "HandlerType",
-                  "enum": ["EXCLUSIVE", "SHARED"],
-                  "description": "If unspecified, defaults to EXCLUSIVE for Virtual Object. This should be unset for Services."
+                  "enum": ["WORKFLOW", "EXCLUSIVE", "SHARED"],
+                  "description": "If unspecified, defaults to EXCLUSIVE for Virtual Object or WORKFLOW for Workflows. This should be unset for Services."
                 },
                 "input": {
                   "type": "object",

--- a/sdk-core/src/test/java/dev/restate/sdk/core/AssertUtils.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/AssertUtils.java
@@ -17,7 +17,7 @@ import com.google.protobuf.MessageLite;
 import dev.restate.generated.service.protocol.Protocol;
 import dev.restate.sdk.common.BindableService;
 import dev.restate.sdk.common.TerminalException;
-import dev.restate.sdk.core.manifest.DeploymentManifestSchema;
+import dev.restate.sdk.core.manifest.EndpointManifestSchema;
 import dev.restate.sdk.core.manifest.Handler;
 import dev.restate.sdk.core.manifest.Service;
 import java.util.Arrays;
@@ -68,10 +68,10 @@ public class AssertUtils {
                 .startsWith(ProtocolException.class.getCanonicalName()));
   }
 
-  public static DeploymentManifestSchemaAssert assertThatDiscovery(Object... services) {
-    return new DeploymentManifestSchemaAssert(
-        new DeploymentManifest(
-                DeploymentManifestSchema.ProtocolMode.BIDI_STREAM,
+  public static EndpointManifestSchemaAssert assertThatDiscovery(Object... services) {
+    return new EndpointManifestSchemaAssert(
+        new EndpointManifest(
+                EndpointManifestSchema.ProtocolMode.BIDI_STREAM,
                 Arrays.stream(services)
                     .flatMap(
                         svc -> {
@@ -85,14 +85,14 @@ public class AssertUtils {
                               .stream();
                         }))
             .manifest(),
-        DeploymentManifestSchemaAssert.class);
+        EndpointManifestSchemaAssert.class);
   }
 
-  public static class DeploymentManifestSchemaAssert
-      extends AbstractObjectAssert<DeploymentManifestSchemaAssert, DeploymentManifestSchema> {
-    public DeploymentManifestSchemaAssert(
-        DeploymentManifestSchema deploymentManifestSchema, Class<?> selfType) {
-      super(deploymentManifestSchema, selfType);
+  public static class EndpointManifestSchemaAssert
+      extends AbstractObjectAssert<EndpointManifestSchemaAssert, EndpointManifestSchema> {
+    public EndpointManifestSchemaAssert(
+        EndpointManifestSchema endpointManifestSchema, Class<?> selfType) {
+      super(endpointManifestSchema, selfType);
     }
 
     public ServiceAssert extractingService(String service) {

--- a/sdk-core/src/test/java/dev/restate/sdk/core/ComponentDiscoveryHandlerTest.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/ComponentDiscoveryHandlerTest.java
@@ -16,8 +16,7 @@ import dev.restate.sdk.common.ServiceType;
 import dev.restate.sdk.common.syscalls.HandlerDefinition;
 import dev.restate.sdk.common.syscalls.HandlerSpecification;
 import dev.restate.sdk.common.syscalls.ServiceDefinition;
-import dev.restate.sdk.core.manifest.DeploymentManifestSchema;
-import dev.restate.sdk.core.manifest.DeploymentManifestSchema.ProtocolMode;
+import dev.restate.sdk.core.manifest.EndpointManifestSchema;
 import dev.restate.sdk.core.manifest.Service;
 import java.util.List;
 import java.util.stream.Stream;
@@ -27,9 +26,9 @@ class ComponentDiscoveryHandlerTest {
 
   @Test
   void handleWithMultipleServices() {
-    DeploymentManifest deploymentManifest =
-        new DeploymentManifest(
-            ProtocolMode.REQUEST_RESPONSE,
+    EndpointManifest deploymentManifest =
+        new EndpointManifest(
+            EndpointManifestSchema.ProtocolMode.REQUEST_RESPONSE,
             Stream.of(
                 ServiceDefinition.of(
                     "MyGreeter",
@@ -40,9 +39,10 @@ class ComponentDiscoveryHandlerTest {
                                 "greet", HandlerType.EXCLUSIVE, CoreSerdes.VOID, CoreSerdes.VOID),
                             null)))));
 
-    DeploymentManifestSchema manifest = deploymentManifest.manifest();
+    EndpointManifestSchema manifest = deploymentManifest.manifest();
 
     assertThat(manifest.getServices()).extracting(Service::getName).containsOnly("MyGreeter");
-    assertThat(manifest.getProtocolMode()).isEqualTo(ProtocolMode.REQUEST_RESPONSE);
+    assertThat(manifest.getProtocolMode())
+        .isEqualTo(EndpointManifestSchema.ProtocolMode.REQUEST_RESPONSE);
   }
 }

--- a/sdk-core/src/test/java/dev/restate/sdk/core/MessageHeaderTest.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/MessageHeaderTest.java
@@ -24,16 +24,4 @@ public class MessageHeaderTest {
                 .encode())
         .isEqualTo(0x0C01_8001_0000_0002L);
   }
-
-  @Test
-  void checkProtocolVersion() {
-    int unknownVersion = Integer.MAX_VALUE & MessageHeader.VERSION_MASK;
-    assertThatThrownBy(
-            () ->
-                MessageHeader.checkProtocolVersion(
-                    new MessageHeader(MessageType.StartMessage, unknownVersion, 0)))
-        .hasMessage(
-            "Unsupported protocol version %d, only version %d is supported",
-            unknownVersion, MessageHeader.SUPPORTED_PROTOCOL_VERSION);
-  }
 }

--- a/sdk-core/src/test/java/dev/restate/sdk/core/MessageHeaderTest.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/MessageHeaderTest.java
@@ -9,7 +9,6 @@
 package dev.restate.sdk.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 

--- a/sdk-core/src/test/java/dev/restate/sdk/core/MockMultiThreaded.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/MockMultiThreaded.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.protobuf.MessageLite;
 import dev.restate.sdk.common.BindableService;
 import dev.restate.sdk.common.syscalls.ServiceDefinition;
-import dev.restate.sdk.core.manifest.DeploymentManifestSchema;
+import dev.restate.sdk.core.manifest.EndpointManifestSchema;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -47,7 +47,7 @@ public final class MockMultiThreaded implements TestDefinitions.TestExecutor {
 
     // Prepare server
     RestateEndpoint.Builder builder =
-        RestateEndpoint.newBuilder(DeploymentManifestSchema.ProtocolMode.BIDI_STREAM)
+        RestateEndpoint.newBuilder(EndpointManifestSchema.ProtocolMode.BIDI_STREAM)
             .bind(serviceDefinition.get(0), bindableService.options());
     RestateEndpoint server = builder.build();
 

--- a/sdk-core/src/test/java/dev/restate/sdk/core/MockSingleThread.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/MockSingleThread.java
@@ -15,7 +15,7 @@ import dev.restate.sdk.common.BindableService;
 import dev.restate.sdk.common.syscalls.ServiceDefinition;
 import dev.restate.sdk.core.TestDefinitions.TestDefinition;
 import dev.restate.sdk.core.TestDefinitions.TestExecutor;
-import dev.restate.sdk.core.manifest.DeploymentManifestSchema;
+import dev.restate.sdk.core.manifest.EndpointManifestSchema;
 import java.time.Duration;
 import java.util.List;
 import org.apache.logging.log4j.ThreadContext;
@@ -45,7 +45,7 @@ public final class MockSingleThread implements TestExecutor {
 
     // Prepare server
     RestateEndpoint.Builder builder =
-        RestateEndpoint.newBuilder(DeploymentManifestSchema.ProtocolMode.BIDI_STREAM)
+        RestateEndpoint.newBuilder(EndpointManifestSchema.ProtocolMode.BIDI_STREAM)
             .bind(serviceDefinition.get(0), bindableService.options());
     RestateEndpoint server = builder.build();
 

--- a/sdk-core/src/test/java/dev/restate/sdk/core/ProtoUtils.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/ProtoUtils.java
@@ -30,10 +30,7 @@ public class ProtoUtils {
    */
   public static MessageHeader headerFromMessage(MessageLite msg) {
     if (msg instanceof Protocol.StartMessage) {
-      return new MessageHeader(
-          MessageType.StartMessage,
-          MessageHeader.SUPPORTED_PROTOCOL_VERSION,
-          msg.getSerializedSize());
+      return new MessageHeader(MessageType.StartMessage, 0, msg.getSerializedSize());
     } else if (msg instanceof Protocol.CompletionMessage) {
       return new MessageHeader(MessageType.CompletionMessage, (short) 0, msg.getSerializedSize());
     }

--- a/sdk-http-vertx/build.gradle.kts
+++ b/sdk-http-vertx/build.gradle.kts
@@ -16,10 +16,6 @@ dependencies {
   implementation(platform(vertxLibs.vertx.bom))
   implementation(vertxLibs.vertx.core)
 
-  // Jackson (we need it for the manifest)
-  implementation(platform(jacksonLibs.jackson.bom))
-  implementation(jacksonLibs.jackson.databind)
-
   // Observability
   implementation(platform(coreLibs.opentelemetry.bom))
   implementation(coreLibs.opentelemetry.api)

--- a/sdk-http-vertx/src/main/java/dev/restate/sdk/http/vertx/RequestHttpServerHandler.java
+++ b/sdk-http-vertx/src/main/java/dev/restate/sdk/http/vertx/RequestHttpServerHandler.java
@@ -20,7 +20,7 @@ import dev.restate.sdk.core.ProtocolException;
 import dev.restate.sdk.core.ResolvedEndpointHandler;
 import dev.restate.sdk.core.RestateEndpoint;
 import dev.restate.sdk.core.ServiceProtocol;
-import dev.restate.sdk.core.manifest.DeploymentManifestSchema;
+import dev.restate.sdk.core.manifest.EndpointManifestSchema;
 import dev.restate.sdk.version.Version;
 import io.netty.util.AsciiString;
 import io.opentelemetry.api.OpenTelemetry;
@@ -196,7 +196,7 @@ class RequestHttpServerHandler implements Handler<HttpServerRequest> {
           .end(errorMessage);
     } else {
       // Compute response and write it back
-      DeploymentManifestSchema response = this.restateEndpoint.handleDiscoveryRequest();
+      EndpointManifestSchema response = this.restateEndpoint.handleDiscoveryRequest();
 
       Buffer responseBuffer;
       try {

--- a/sdk-http-vertx/src/main/java/dev/restate/sdk/http/vertx/RestateHttpEndpointBuilder.java
+++ b/sdk-http-vertx/src/main/java/dev/restate/sdk/http/vertx/RestateHttpEndpointBuilder.java
@@ -12,7 +12,7 @@ import dev.restate.sdk.auth.RequestIdentityVerifier;
 import dev.restate.sdk.common.BindableService;
 import dev.restate.sdk.common.syscalls.ServiceDefinition;
 import dev.restate.sdk.core.RestateEndpoint;
-import dev.restate.sdk.core.manifest.DeploymentManifestSchema;
+import dev.restate.sdk.core.manifest.EndpointManifestSchema;
 import io.opentelemetry.api.OpenTelemetry;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Vertx;
@@ -43,7 +43,7 @@ public class RestateHttpEndpointBuilder {
 
   private final Vertx vertx;
   private final RestateEndpoint.Builder endpointBuilder =
-      RestateEndpoint.newBuilder(DeploymentManifestSchema.ProtocolMode.BIDI_STREAM);
+      RestateEndpoint.newBuilder(EndpointManifestSchema.ProtocolMode.BIDI_STREAM);
   private OpenTelemetry openTelemetry = OpenTelemetry.noop();
   private HttpServerOptions options =
       new HttpServerOptions()

--- a/sdk-http-vertx/src/test/kotlin/dev/restate/sdk/http/vertx/HttpVertxTestExecutor.kt
+++ b/sdk-http-vertx/src/test/kotlin/dev/restate/sdk/http/vertx/HttpVertxTestExecutor.kt
@@ -9,6 +9,8 @@
 package dev.restate.sdk.http.vertx
 
 import com.google.protobuf.MessageLite
+import dev.restate.generated.service.protocol.Protocol
+import dev.restate.sdk.core.ServiceProtocol
 import dev.restate.sdk.core.TestDefinitions.TestDefinition
 import dev.restate.sdk.core.TestDefinitions.TestExecutor
 import io.vertx.core.Vertx
@@ -57,7 +59,16 @@ class HttpVertxTestExecutor(private val vertx: Vertx) : TestExecutor {
               .coAwait()
 
       // Prepare request header and send them
-      request.setChunked(true).putHeader(HttpHeaders.CONTENT_TYPE, "application/restate")
+      request
+          .setChunked(true)
+          .putHeader(
+              HttpHeaders.CONTENT_TYPE,
+              ServiceProtocol.serviceProtocolVersionToHeaderValue(
+                  Protocol.ServiceProtocolVersion.V1))
+          .putHeader(
+              HttpHeaders.ACCEPT,
+              ServiceProtocol.serviceProtocolVersionToHeaderValue(
+                  Protocol.ServiceProtocolVersion.V1))
       request.sendHead().coAwait()
 
       launch {

--- a/sdk-http-vertx/src/test/kotlin/dev/restate/sdk/http/vertx/RestateHttpEndpointTest.kt
+++ b/sdk-http-vertx/src/test/kotlin/dev/restate/sdk/http/vertx/RestateHttpEndpointTest.kt
@@ -16,7 +16,7 @@ import dev.restate.generated.service.protocol.Protocol.*
 import dev.restate.sdk.common.CoreSerdes
 import dev.restate.sdk.core.ProtoUtils.*
 import dev.restate.sdk.core.ServiceProtocol
-import dev.restate.sdk.core.manifest.DeploymentManifestSchema
+import dev.restate.sdk.core.manifest.EndpointManifestSchema
 import dev.restate.sdk.http.vertx.testservices.BlockingGreeter
 import dev.restate.sdk.http.vertx.testservices.greeter
 import io.netty.handler.codec.http.HttpResponseStatus
@@ -232,8 +232,8 @@ internal class RestateHttpEndpointTest {
         // Parse response
         val responseBody = response.body().coAwait()
         // Compute response and write it back
-        val discoveryResponse: DeploymentManifestSchema =
-            ObjectMapper().readValue(responseBody.bytes, DeploymentManifestSchema::class.java)
+        val discoveryResponse: EndpointManifestSchema =
+            ObjectMapper().readValue(responseBody.bytes, EndpointManifestSchema::class.java)
 
         assertThat(discoveryResponse.services)
             .map<String> { it.name }

--- a/sdk-lambda/build.gradle.kts
+++ b/sdk-lambda/build.gradle.kts
@@ -13,10 +13,6 @@ dependencies {
   api(lambdaLibs.core)
   api(lambdaLibs.events)
 
-  // Jackson (we need it for the manifest)
-  implementation(platform(jacksonLibs.jackson.bom))
-  implementation(jacksonLibs.jackson.databind)
-
   implementation(platform(coreLibs.opentelemetry.bom))
   implementation(coreLibs.opentelemetry.api)
 

--- a/sdk-lambda/src/main/java/dev/restate/sdk/lambda/RestateLambdaEndpoint.java
+++ b/sdk-lambda/src/main/java/dev/restate/sdk/lambda/RestateLambdaEndpoint.java
@@ -21,7 +21,7 @@ import dev.restate.sdk.core.ProtocolException;
 import dev.restate.sdk.core.ResolvedEndpointHandler;
 import dev.restate.sdk.core.RestateEndpoint;
 import dev.restate.sdk.core.ServiceProtocol;
-import dev.restate.sdk.core.manifest.DeploymentManifestSchema;
+import dev.restate.sdk.core.manifest.EndpointManifestSchema;
 import dev.restate.sdk.version.Version;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapGetter;
@@ -206,7 +206,7 @@ public final class RestateLambdaEndpoint {
       return response;
     } else {
       // Compute response and write it back
-      DeploymentManifestSchema responseManifest = this.restateEndpoint.handleDiscoveryRequest();
+      EndpointManifestSchema responseManifest = this.restateEndpoint.handleDiscoveryRequest();
       byte[] serializedManifest;
       try {
         serializedManifest =

--- a/sdk-lambda/src/main/java/dev/restate/sdk/lambda/RestateLambdaEndpointBuilder.java
+++ b/sdk-lambda/src/main/java/dev/restate/sdk/lambda/RestateLambdaEndpointBuilder.java
@@ -12,14 +12,14 @@ import dev.restate.sdk.auth.RequestIdentityVerifier;
 import dev.restate.sdk.common.BindableService;
 import dev.restate.sdk.common.syscalls.ServiceDefinition;
 import dev.restate.sdk.core.RestateEndpoint;
-import dev.restate.sdk.core.manifest.DeploymentManifestSchema;
+import dev.restate.sdk.core.manifest.EndpointManifestSchema;
 import io.opentelemetry.api.OpenTelemetry;
 
 /** Endpoint builder for a Restate AWS Lambda Endpoint, to serve Restate service. */
 public final class RestateLambdaEndpointBuilder {
 
   private final RestateEndpoint.Builder restateEndpoint =
-      RestateEndpoint.newBuilder(DeploymentManifestSchema.ProtocolMode.REQUEST_RESPONSE);
+      RestateEndpoint.newBuilder(EndpointManifestSchema.ProtocolMode.REQUEST_RESPONSE);
   private OpenTelemetry openTelemetry = OpenTelemetry.noop();
 
   /**

--- a/sdk-lambda/src/test/java/dev/restate/sdk/lambda/LambdaHandlerTest.java
+++ b/sdk-lambda/src/test/java/dev/restate/sdk/lambda/LambdaHandlerTest.java
@@ -23,7 +23,7 @@ import dev.restate.generated.service.discovery.Discovery;
 import dev.restate.generated.service.protocol.Protocol;
 import dev.restate.sdk.core.ProtoUtils;
 import dev.restate.sdk.core.ServiceProtocol;
-import dev.restate.sdk.core.manifest.DeploymentManifestSchema;
+import dev.restate.sdk.core.manifest.EndpointManifestSchema;
 import dev.restate.sdk.core.manifest.Service;
 import dev.restate.sdk.lambda.testservices.JavaCounterDefinitions;
 import dev.restate.sdk.lambda.testservices.MyServicesHandler;
@@ -111,8 +111,8 @@ class LambdaHandlerTest {
     assertThat(response.getIsBase64Encoded()).isTrue();
     byte[] decodedStringResponse = Base64.getDecoder().decode(response.getBody());
     // Compute response and write it back
-    DeploymentManifestSchema discoveryResponse =
-        new ObjectMapper().readValue(decodedStringResponse, DeploymentManifestSchema.class);
+    EndpointManifestSchema discoveryResponse =
+        new ObjectMapper().readValue(decodedStringResponse, EndpointManifestSchema.class);
 
     assertThat(discoveryResponse.getServices())
         .map(Service::getName)


### PR DESCRIPTION
This commit lets the Java SDK extract the accepted ServiceDiscoveryProtocolVersions
from the accept header of the discovery request and sends a correspondingly encoded
response back if the endpoint supports the service discovery protocol version.

Likewise the SDK is now extracting the service protocol version from the content type
header when the service is invoked. If the endpoint does not support the specified
protocol version, then it will reject the request with a status code 415.

We are no longer sending the protocol version via the message headers
of the start message. This commit removes this logic.

This fixes https://github.com/restatedev/sdk-java/issues/317.