### PR TITLE
Pin java toolchain version to 11 for buildSrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,6 +7,11 @@ repositories {
     gradlePluginPortal()
 }
 
+java {
+    // Pin to a version that is also supported by Kotlin
+    toolchain { languageVersion = JavaLanguageVersion.of(11) }
+}
+
 
 dependencies {
     implementation("net.ltgt.gradle:gradle-errorprone-plugin:4.0.0")


### PR DESCRIPTION
If this is not fixed, then the build can fail if one is running locally with Java version 23 which is not yet supported by Kotlin.

This fixes #390.