### PR TITLE
Remove usage of `LogManager.getLogger()`

### DIFF
--- a/sdk-api-kotlin/src/main/kotlin/dev/restate/sdk/kotlin/HandlerRunner.kt
+++ b/sdk-api-kotlin/src/main/kotlin/dev/restate/sdk/kotlin/HandlerRunner.kt
@@ -28,7 +28,7 @@ internal constructor(
 ) : dev.restate.sdk.common.syscalls.HandlerRunner<REQ, RES, HandlerRunner.Options> {
 
   companion object {
-    private val LOG = LogManager.getLogger()
+    private val LOG = LogManager.getLogger(HandlerRunner::class.java)
 
     fun <REQ, RES, CTX : Context> of(
         runner: suspend (CTX, REQ) -> RES


### PR DESCRIPTION
Fix #419