### PR TITLE
bump handlebars dependency from 4.3.1 to 4.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
   aws-lambda-core = 'com.amazonaws:aws-lambda-java-core:1.2.3'
   aws-lambda-events = 'com.amazonaws:aws-lambda-java-events:3.11.5'
   google-findbugs-jsr305 = 'com.google.code.findbugs:jsr305:3.0.2'
-  handlebars = 'com.github.jknack:handlebars:4.3.1'
+  handlebars = 'com.github.jknack:handlebars:4.5.0'
   jspecify = 'org.jspecify:jspecify:1.0.0'
   jwt = 'com.nimbusds:nimbus-jose-jwt:9.47'
   mutiny = 'io.smallrye.reactive:mutiny:2.7.0'

--- a/sdk-api-gen-common/build.gradle.kts
+++ b/sdk-api-gen-common/build.gradle.kts
@@ -9,7 +9,11 @@ description = "Restate SDK API Gen Common"
 dependencies {
   compileOnly(libs.jspecify)
 
-  api(libs.handlebars)
+  api(libs.handlebars) {
+    // exclude nashorn-core, since it is not license compliant and is only
+    // needed for javascript in templates which we don't use.
+    exclude(group = "org.openjdk.nashorn", module = "nashorn-core")
+  }
   api(project(":sdk-common"))
 
   // We need it to silence the slf4j warning (coming from handlebars)

--- a/sdk-api-gen-common/src/main/java/dev/restate/sdk/gen/template/HandlebarsTemplateEngine.java
+++ b/sdk-api-gen-common/src/main/java/dev/restate/sdk/gen/template/HandlebarsTemplateEngine.java
@@ -13,7 +13,6 @@ import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
 import com.github.jknack.handlebars.context.FieldValueResolver;
 import com.github.jknack.handlebars.helper.StringHelpers;
-import com.github.jknack.handlebars.internal.text.StringEscapeUtils;
 import com.github.jknack.handlebars.io.TemplateLoader;
 import dev.restate.common.function.ThrowingFunction;
 import dev.restate.sdk.endpoint.definition.ServiceType;
@@ -26,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.commons.text.StringEscapeUtils;
 
 public class HandlebarsTemplateEngine {
 


### PR DESCRIPTION
Resolves a build warning due to incompatible versions of slf4j.

Change in HandlebarsTemplateEngine is due to a change in handlebars where they no longer shade commons text in their jar.

This breaks the licens check, but I don't know the implications.