### PR TITLE
Fix handling of annotations on parameters, such as @Raw annotation.

### DIFF
--- a/bytebuddy-proxy-support/src/main/java/dev/restate/bytebuddy/proxysupport/ByteBuddyProxyFactory.java
+++ b/bytebuddy-proxy-support/src/main/java/dev/restate/bytebuddy/proxysupport/ByteBuddyProxyFactory.java
@@ -8,6 +8,7 @@
 // https://github.com/restatedev/sdk-java/blob/main/LICENSE
 package dev.restate.bytebuddy.proxysupport;
 
+import static dev.restate.common.reflections.ReflectionUtils.findRestateAnnotatedClass;
 import static net.bytebuddy.matcher.ElementMatchers.*;
 
 import dev.restate.common.reflections.ProxyFactory;
@@ -95,14 +96,8 @@ public final class ByteBuddyProxyFactory implements ProxyFactory {
     if (!clazz.isInterface()) {
       // We perform here some additional validation of the handlers that won't be executed by
       // bytebuddy and can easily lead to strange behavior
-      var methods =
-          ReflectionUtils.getUniqueDeclaredMethods(
-              clazz,
-              method ->
-                  ReflectionUtils.findAnnotation(method, Handler.class) != null
-                      || ReflectionUtils.findAnnotation(method, Shared.class) != null
-                      || ReflectionUtils.findAnnotation(method, Workflow.class) != null
-                      || ReflectionUtils.findAnnotation(method, Exclusive.class) != null);
+      var restateAnnotatedClazz = findRestateAnnotatedClass(clazz);
+      var methods = ReflectionUtils.findRestateHandlers(restateAnnotatedClazz);
       for (var method : methods) {
         validateMethod(method);
       }

--- a/common/src/main/java/dev/restate/serde/Serde.java
+++ b/common/src/main/java/dev/restate/serde/Serde.java
@@ -153,6 +153,11 @@ public interface Serde<T extends @Nullable Object> extends TypeTag<T> {
         public byte[] deserialize(@NonNull Slice value) {
           return value.toByteArray();
         }
+
+        @Override
+        public String contentType() {
+          return "application/octet-stream";
+        }
       };
 
   /** Passthrough serializer/deserializer */

--- a/sdk-core/build.gradle.kts
+++ b/sdk-core/build.gradle.kts
@@ -116,6 +116,7 @@ tasks {
             "dev.restate.sdk.core.javaapi.reflections.ObjectGreeterImplementedFromInterface",
             "dev.restate.sdk.core.javaapi.reflections.PrimitiveTypes",
             "dev.restate.sdk.core.javaapi.reflections.RawInputOutput",
+            "dev.restate.sdk.core.javaapi.reflections.RawService",
             "dev.restate.sdk.core.javaapi.reflections.ServiceGreeter",
         )
 

--- a/sdk-core/src/test/java/dev/restate/sdk/core/javaapi/reflections/RawService.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/javaapi/reflections/RawService.java
@@ -1,0 +1,22 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate Java SDK,
+// which is released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/sdk-java/blob/main/LICENSE
+package dev.restate.sdk.core.javaapi.reflections;
+
+import dev.restate.sdk.annotation.Handler;
+import dev.restate.sdk.annotation.Name;
+import dev.restate.sdk.annotation.Raw;
+import dev.restate.sdk.annotation.Service;
+
+@Service
+@Name("RawService")
+public interface RawService {
+  @Handler
+  @Raw
+  byte[] echo(@Raw byte[] input);
+}

--- a/sdk-core/src/test/java/dev/restate/sdk/core/javaapi/reflections/RawServiceImpl.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/javaapi/reflections/RawServiceImpl.java
@@ -1,0 +1,16 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate Java SDK,
+// which is released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/sdk-java/blob/main/LICENSE
+package dev.restate.sdk.core.javaapi.reflections;
+
+public class RawServiceImpl implements RawService {
+  @Override
+  public byte[] echo(byte[] input) {
+    return input;
+  }
+}

--- a/sdk-core/src/test/java/dev/restate/sdk/core/javaapi/reflections/ReflectionDiscoveryTest.java
+++ b/sdk-core/src/test/java/dev/restate/sdk/core/javaapi/reflections/ReflectionDiscoveryTest.java
@@ -19,6 +19,7 @@ import dev.restate.sdk.core.generated.manifest.Service;
 import dev.restate.sdk.core.javaapi.GreeterWithExplicitName;
 import dev.restate.sdk.core.javaapi.GreeterWithExplicitNameHandlers;
 import dev.restate.sdk.endpoint.Endpoint;
+import dev.restate.serde.Serde;
 import org.junit.jupiter.api.Test;
 
 public class ReflectionDiscoveryTest {
@@ -51,6 +52,44 @@ public class ReflectionDiscoveryTest {
         .extracting(Handler::getOutput, type(Output.class))
         .extracting(Output::getContentType)
         .isEqualTo("application/vnd.my.custom");
+  }
+
+  @Test
+  void checkRawInputContentType() {
+    assertThatDiscovery(new RawInputOutput())
+        .extractingService("RawInputOutput")
+        .extractingHandler("rawInput")
+        .extracting(Handler::getInput, type(Input.class))
+        .extracting(Input::getContentType)
+        .isEqualTo(Serde.RAW.contentType());
+  }
+
+  @Test
+  void checkRawOutputContentType() {
+    assertThatDiscovery(new RawInputOutput())
+        .extractingService("RawInputOutput")
+        .extractingHandler("rawOutput")
+        .extracting(Handler::getOutput, type(Output.class))
+        .extracting(Output::getContentType)
+        .isEqualTo(Serde.RAW.contentType());
+  }
+
+  @Test
+  void checkRawInfoFromInterface() {
+    var handlerAssert =
+        assertThatDiscovery(new RawServiceImpl())
+            .extractingService("RawService")
+            .extractingHandler("echo");
+
+    handlerAssert
+        .extracting(Handler::getInput, type(Input.class))
+        .extracting(Input::getContentType)
+        .isEqualTo(Serde.RAW.contentType());
+
+    handlerAssert
+        .extracting(Handler::getOutput, type(Output.class))
+        .extracting(Output::getContentType)
+        .isEqualTo(Serde.RAW.contentType());
   }
 
   @Test


### PR DESCRIPTION
This commit changes how we deal with annotations -> instead of looking at the annotations always from the implementation class up to the parent class/interface, we first look for the parent class/interface where the restate service annotation is placed, and then in there we check the other annotations (@Handler, @Raw, etc)