### PR TITLE
[Bugfix] Adjust `$ref` handling logic in `DefaultJsonSchemaFactory`

### DIFF
--- a/sdk-serde-kotlinx/src/main/kotlin/dev/restate/serde/kotlinx/DefaultJsonSchemaFactory.kt
+++ b/sdk-serde-kotlinx/src/main/kotlin/dev/restate/serde/kotlinx/DefaultJsonSchemaFactory.kt
@@ -23,7 +23,6 @@ import io.github.smiley4.schemakenerator.jsonschema.jsonDsl.array
 import io.github.smiley4.schemakenerator.serialization.SerializationSteps.analyzeTypeUsingKotlinxSerialization
 import io.github.smiley4.schemakenerator.serialization.SerializationSteps.initial
 import io.github.smiley4.schemakenerator.serialization.SerializationSteps.renameMembers
-import kotlin.collections.set
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
@@ -126,8 +125,10 @@ object DefaultJsonSchemaFactory : KotlinSerializationSerdeFactory.JsonSchemaFact
   private fun JsonObject.fixRefsPrefix(rootDefinition: String) {
     this.properties.computeIfPresent("\$ref") { key, node ->
       if (node is JsonTextValue) {
-        if (node.value.startsWith(rootDefinition)) {
-          JsonTextValue("#/" + node.value.removePrefix(rootDefinition))
+        if (node.value == rootDefinition) {
+          JsonTextValue("#/")
+        } else if (node.value.startsWith("$rootDefinition/")) {
+          JsonTextValue("#/" + node.value.removePrefix("$rootDefinition/"))
         } else {
           JsonTextValue("#/\$defs/" + node.value.removePrefix("#/definitions/"))
         }

--- a/sdk-serde-kotlinx/src/test/kotlin/dev/restate/serde/kotlinx/KotlinxSerdeTest.kt
+++ b/sdk-serde-kotlinx/src/test/kotlin/dev/restate/serde/kotlinx/KotlinxSerdeTest.kt
@@ -176,6 +176,71 @@ class KotlinxSerdeTest {
     )
   }
 
+  @Serializable
+  enum class TaskStatus {
+    TODO,
+    IN_PROGRESS,
+    DONE,
+  }
+
+  @Serializable
+  enum class PriorityOrder {
+    HIGH,
+    MID,
+    LOW,
+  }
+
+  @Serializable
+  data class Task(val title: String, val status: TaskStatus, val priority: PriorityOrder)
+
+  @Test
+  fun schemaGenWithExternalEnum() {
+    testSchemaGen<Task>(
+        $$"""
+        {
+                 "type": "object",
+                 "required": [
+                    "title",
+                    "status",
+                    "priority"
+                 ],
+                 "properties": {
+                    "title": {
+                       "type": "string"
+                    },
+                    "priority": {
+                       "$ref": "#/$defs/PriorityOrder"
+                    },
+                    "status": {
+                       "$ref": "#/$defs/TaskStatus"
+                    }
+                 },
+                 "title": "Task",
+                 "$schema": "https://json-schema.org/draft/2020-12/schema",
+                 "$defs": {
+                    "TaskStatus": {
+                       "enum": [
+                          "TODO",
+                          "IN_PROGRESS",
+                          "DONE"
+                       ],
+                       "title": "TaskStatus"
+                    },
+                    "PriorityOrder": {
+                       "enum": [
+                          "HIGH",
+                          "MID",
+                          "LOW"
+                       ],
+                       "title": "PriorityOrder"
+                    }
+                 }
+              }
+        """
+            .trimIndent()
+    )
+  }
+
   inline fun <reified T : Any?> testSchemaGen(expectedSchema: String) {
     val expectedJsonElement = Json.decodeFromString<JsonElement>(expectedSchema)
     val actualSchema =


### PR DESCRIPTION
To avoid replacing nested type name if it shares the prefix of the root class name.

When you have a type that shares the name of it's parent type (eg: Task & TaskType), with the way the current `fixRefsPrefix` works (recurses through all subtypes to handle nested types) you end up replacing the def path of the subtype and it becomes unserialisable and crashes at runtime, and you have to use custom serialisers or rename your class. This checks that the root definition is followed by a / (to indicate nesting) before replacing it).

<img width="1209" height="710" alt="image" src="https://github.com/user-attachments/assets/c45155da-9cfc-494c-80cd-f167c41c2baf" />